### PR TITLE
return key_id when email is not present for import_and_trust

### DIFF
--- a/lib/io_streams/pgp.rb
+++ b/lib/io_streams/pgp.rb
@@ -261,7 +261,7 @@ module IOStreams
 
       import(key: key)
       set_trust(email: email, key_id: key_id)
-      email
+      email || key_id
     end
 
     # Set the trust level for an existing key.


### PR DESCRIPTION
### Issue # (if available)

None

### Description of changes

When using a key that does not have an email, `import_and_trust` returns `nil`.

For my use case, this is causing an issue when doing something like

```ruby
IOStreams::Pgp::Writer.file(destination_path, import_and_trust_key: public_key_without_email) do |io|
    io.write('hello world')
end
```

It looks like some changes for supporting keys without emails were done in https://github.com/rocketjob/iostreams/pull/10 (thanks @andresfcamacho) - this small change was probably missed

These changes work for my use case and existing unit tests pass but I'm not very familiar with the entire codebase so feel free to suggest changes.

### Thanks

Thanks for making `iostreams` :smile:  It's an awesome gem!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
