### PR TITLE
Jruby Unzip and Parse CSV file

### DIFF
--- a/lib/io_streams/version.rb
+++ b/lib/io_streams/version.rb
@@ -1,3 +1,3 @@
 module IOStreams
-  VERSION = "1.6.0".freeze
+  VERSION = "1.6.1".freeze
 end

--- a/lib/io_streams/zip/reader.rb
+++ b/lib/io_streams/zip/reader.rb
@@ -20,7 +20,7 @@ module IOStreams
       if defined?(JRuby)
         # Java has built-in support for Zip files
         def self.file(file_name, entry_file_name: nil, &block)
-          if entry_file_name.include?(".CSV")
+          if entry_file_name&.include?(".CSV")
             get_file_io(file_name, entry_file_name, &block)
           else
             fin = Java::JavaIo::FileInputStream.new(file_name)

--- a/lib/io_streams/zip/reader.rb
+++ b/lib/io_streams/zip/reader.rb
@@ -19,14 +19,18 @@ module IOStreams
       #   end
       if defined?(JRuby)
         # Java has built-in support for Zip files
-        def self.file(file_name, entry_file_name: nil)
-          fin = Java::JavaIo::FileInputStream.new(file_name)
-          zin = Java::JavaUtilZip::ZipInputStream.new(fin)
+        def self.file(file_name, entry_file_name: nil, &block)
+          if entry_file_name.include?(".CSV")
+            get_file_io(file_name, entry_file_name, &block)
+          else
+            fin = Java::JavaIo::FileInputStream.new(file_name)
+            zin = Java::JavaUtilZip::ZipInputStream.new(fin)
 
-          get_entry(zin, entry_file_name) ||
-            raise(Java::JavaUtilZip::ZipException, "File #{entry_file_name} not found within zip file.")
+            get_entry(zin, entry_file_name) ||
+              raise(Java::JavaUtilZip::ZipException, "File #{entry_file_name} not found within zip file.")
 
-          yield(zin.to_io)
+            yield(zin.to_io)
+          end
         ensure
           zin&.close
           fin&.close
@@ -48,20 +52,24 @@ module IOStreams
         # The input stream from the first file found in the zip file is passed
         # to the supplied block
         def self.file(file_name, entry_file_name: nil, &block)
-          Utils.load_soft_dependency("rubyzip v1.x", "Read Zip", "zip") unless defined?(::Zip)
+          get_file_io(file_name, entry_file_name, &block)
+        end
+      end
 
-          ::Zip::File.open(file_name) do |zip_file|
-            if entry_file_name
-              zip_file.get_input_stream(entry_file_name, &block)
-            else
-              result = nil
-              # Return the first file
-              zip_file.each do |entry|
-                result = entry.get_input_stream(&block)
-                break
-              end
-              result
+      def self.get_file_io(file_name, entry_file_name, &block)
+        Utils.load_soft_dependency("rubyzip v1.x", "Read Zip", "zip") unless defined?(::Zip)
+
+        ::Zip::File.open(file_name) do |zip_file|
+          if entry_file_name
+            zip_file.get_input_stream(entry_file_name, &block)
+          else
+            result = nil
+            # Return the first file
+            zip_file.each do |entry|
+              result = entry.get_input_stream(&block)
+              break
             end
+            result
           end
         end
       end

--- a/test/zip_reader_test.rb
+++ b/test/zip_reader_test.rb
@@ -12,6 +12,10 @@ class ZipReaderTest < Minitest::Test
       File.join(File.dirname(__FILE__), "files", "multiple_files.zip")
     end
 
+    let :csv_zip_file_name do
+      'https://www5.fdic.gov/idasp/Offices2.zip'
+    end
+
     let :contents_test_txt do
       File.read(File.join(File.dirname(__FILE__), "files", "text.txt"))
     end
@@ -38,6 +42,14 @@ class ZipReaderTest < Minitest::Test
       it "reads another entry within zip file" do
         result = IOStreams::Zip::Reader.file(multiple_zip_file_name, entry_file_name: "test.json", &:read)
         assert_equal contents_test_json, result
+      end
+
+      it "parses CSV which is inside a zip" do        
+        IOStreams.path(csv_zip_file_name).option(:zip, entry_file_name: 'OFFICES2_ALL.CSV').reader do |io|
+          csv    = ::CSV.new(io, headers: true)
+          row = csv.first
+          assert Date.parse(row['RUNDATE'])
+        end
       end
 
       # it 'reads from a stream' do


### PR DESCRIPTION
Unzipping ZIP and reading CSV when running with JRUBY is having encoding issues, calling common method incase file is CSV.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
