### PR TITLE
Fix: Prevent embedded_within auto-set for PSV files labeled as .csv

### DIFF
--- a/lib/io_streams/stream.rb
+++ b/lib/io_streams/stream.rb
@@ -326,8 +326,18 @@ module IOStreams
       builder.reader(io_stream, &block)
     end
 
-    def line_reader(embedded_within: nil, **args)
-      embedded_within = '"' if embedded_within.nil? && builder.file_name&.include?(".csv")
+    def line_reader(embedded_within: :auto, **args)
+      # Only set embedded_within for CSV files, not PSV files (even if labeled as .csv)
+      # Check the detected or explicitly set format rather than just the filename extension
+      # Use :auto as default to distinguish between "not provided" and "explicitly nil"
+      if embedded_within == :auto && builder.file_name&.include?(".csv")
+        detected_format = builder.format
+        # Only set embedded_within for actual CSV format, not PSV files mislabeled as CSV
+        # If format is explicitly set to :psv (via .format(:psv)), don't set embedded_within
+        embedded_within = detected_format == :psv ? nil : '"'
+      elsif embedded_within == :auto
+        embedded_within = nil
+      end
 
       stream_reader do |io|
         yield IOStreams::Line::Reader.new(io,
@@ -338,7 +348,7 @@ module IOStreams
     end
 
     # Iterate over a file / stream returning each line as an array, one at a time.
-    def row_reader(delimiter: nil, embedded_within: nil, **args)
+    def row_reader(delimiter: nil, embedded_within: :auto, **args)
       line_reader(delimiter: delimiter, embedded_within: embedded_within) do |io|
         yield IOStreams::Row::Reader.new(
           io,
@@ -351,7 +361,7 @@ module IOStreams
     end
 
     # Iterate over a file / stream returning each line as a hash, one at a time.
-    def record_reader(delimiter: nil, embedded_within: nil, **args)
+    def record_reader(delimiter: nil, embedded_within: :auto, **args)
       line_reader(delimiter: delimiter, embedded_within: embedded_within) do |io|
         yield IOStreams::Record::Reader.new(
           io,

--- a/test/files/malformed_pipe_csv.csv
+++ b/test/files/malformed_pipe_csv.csv
@@ -1,0 +1,4 @@
+name|description|zip
+Jack|Firstname is Jack|234567
+O"neil|Firstname is O"neil|234568
+Smith|Description with "quote|234569

--- a/test/line_reader_test.rb
+++ b/test/line_reader_test.rb
@@ -22,6 +22,10 @@ class LineReaderTest < Minitest::Test
       File.join(File.dirname(__FILE__), "files", "unclosed_quote_large_test.csv")
     end
 
+    let :malformed_pipe_csv_file do
+      File.join(File.dirname(__FILE__), "files", "malformed_pipe_csv.csv")
+    end
+
     let :data do
       data = []
       File.open(file_name, "rt") do |file|
@@ -84,6 +88,47 @@ class LineReaderTest < Minitest::Test
             end
           end
           assert_includes exc.message, "Unbalanced delimited field, delimiter:"
+        end
+
+        it "raises error for malformed pipe-delimited CSV with unclosed quotes" do
+          exc = assert_raises(IOStreams::Errors::MalformedDataError) do
+            IOStreams::Line::Reader.file(malformed_pipe_csv_file, embedded_within: '"') do |io|
+              io.each { |line| }
+            end
+          end
+          assert_includes exc.message, "Unbalanced delimited field, delimiter:"
+        end
+
+        it "can count raw lines in malformed pipe-delimited CSV by disabling embedded_within" do
+          line_count = 0
+          IOStreams::Line::Reader.file(malformed_pipe_csv_file, embedded_within: nil) do |io|
+            line_count = io.each { |line| }
+          end
+          # Should count 4 raw lines (header + 3 data rows) without parsing quotes
+          assert_equal 4, line_count
+        end
+
+        it "raises error when using IOStreams.path() on malformed pipe-delimited CSV (production scenario)" do
+          # This reproduces the production issue: PSV file labeled as .csv with quotes in data (e.g., O"neil)
+          # The .csv extension triggers embedded_within: '"' which tries to parse quotes and fails on odd quote counts
+          exc = assert_raises(IOStreams::Errors::MalformedDataError) do
+            IOStreams.path(malformed_pipe_csv_file).each(:line) do |line|
+              # This will fail because .csv extension triggers embedded_within: '"'
+              # and the file has quotes in pipe-delimited data (like O"neil) causing unbalanced quote error
+            end
+          end
+          assert_includes exc.message, "Unbalanced delimited field, delimiter:"
+        end
+
+        it "can count raw lines using IOStreams.path() by explicitly disabling embedded_within" do
+          # This is the production fix: explicitly pass embedded_within: nil
+          # This allows counting raw lines in pipe-delimited files labeled as .csv without quote parsing
+          line_count = 0
+          IOStreams.path(malformed_pipe_csv_file).each(:line, embedded_within: nil) do |line|
+            line_count += 1
+          end
+          # Should count 4 raw lines (header + 3 data rows) without parsing quotes
+          assert_equal 4, line_count
         end
       end
     end

--- a/test/stream_test.rb
+++ b/test/stream_test.rb
@@ -573,5 +573,87 @@ class StreamTest < Minitest::Test
         end
       end
     end
+
+    describe "production scenario: pipe-delimited file labeled as .csv" do
+      let :temp_file do
+        Tempfile.new(["test", ".csv"])
+      end
+
+      let :file_name do
+        temp_file.path
+      end
+
+      after do
+        temp_file.delete
+      end
+
+      # Simulate RocketJob writing pipe-delimited data with .csv extension
+      # This replicates: output_category format: :csv but data is actually pipe-delimited
+      it "fails when reading pipe-delimited .csv file with quotes in data (production bug)" do
+        # Write pipe-delimited data to a .csv file (simulating RocketJob scenario)
+        # The file has .csv extension but contains pipe-delimited data with quotes
+        pipe_delimited_data = [
+          "name|description|zip",
+          "Jack|Firstname is Jack|234567",
+          "O\"neil|Firstname is O\"neil|234568",
+          "Smith|Description with \"quote|234569"
+        ].join("\n") + "\n"
+
+        File.write(file_name, pipe_delimited_data)
+
+        # This should FAIL with current code because .csv extension triggers embedded_within: '"'
+        # and the pipe-delimited data has quotes that cause unbalanced delimiter errors
+        exc = assert_raises(IOStreams::Errors::MalformedDataError) do
+          IOStreams.path(file_name).each(:line) do |line|
+            # Reading should fail here
+          end
+        end
+        assert_includes exc.message, "Unbalanced delimited field, delimiter:"
+      end
+
+      it "succeeds when explicitly disabling embedded_within (production fix option 1)" do
+        # Write pipe-delimited data to a .csv file
+        pipe_delimited_data = [
+          "name|description|zip",
+          "Jack|Firstname is Jack|234567",
+          "O\"neil|Firstname is O\"neil|234568",
+          "Smith|Description with \"quote|234569"
+        ].join("\n") + "\n"
+
+        File.write(file_name, pipe_delimited_data)
+
+        # Fix: Explicitly disable embedded_within to read raw lines
+        lines = []
+        IOStreams.path(file_name).each(:line, embedded_within: nil) do |line|
+          lines << line
+        end
+
+        assert_equal 4, lines.size
+        assert_equal "name|description|zip", lines[0]
+        assert_equal "O\"neil|Firstname is O\"neil|234568", lines[2]
+      end
+
+      it "succeeds when explicitly setting format to :psv (production fix option 2)" do
+        # Write pipe-delimited data to a .csv file
+        pipe_delimited_data = [
+          "name|description|zip",
+          "Jack|Firstname is Jack|234567",
+          "O\"neil|Firstname is O\"neil|234568",
+          "Smith|Description with \"quote|234569"
+        ].join("\n") + "\n"
+
+        File.write(file_name, pipe_delimited_data)
+
+        # Fix: Explicitly set format to :psv so embedded_within is not set
+        lines = []
+        IOStreams.path(file_name).format(:psv).each(:line) do |line|
+          lines << line
+        end
+
+        assert_equal 4, lines.size
+        assert_equal "name|description|zip", lines[0]
+        assert_equal "O\"neil|Firstname is O\"neil|234568", lines[2]
+      end
+    end
   end
 end


### PR DESCRIPTION
When reading files with .csv extension, IOStreams automatically sets embedded_within: '"' to handle embedded newlines in CSV files. However, this causes errors when the file is actually pipe-delimited (PSV format) but labeled as .csv, especially when the data contains quotes (e.g., O"neil).

This fix:
- Checks the detected or explicitly set format before auto-setting embedded_within
- If format is :psv (even if file is named .csv), embedded_within is not set
- Allows explicit embedded_within: nil to disable quote parsing
- Uses :auto as default to distinguish between 'not provided' and 'explicitly nil'

Fixes issue where pipe-delimited files with .csv.pgp extension fail with 'Unbalanced delimited field' errors when quotes appear in the data.

Test coverage:
- Added test file with pipe-delimited data containing quotes
- Added tests to verify the production scenario fails correctly
- Added tests to verify both fix options work (embedded_within: nil and format: :psv)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.