### PR TITLE
Security enhancements

### DIFF
--- a/docs/path.md
+++ b/docs/path.md
@@ -333,10 +333,58 @@ Notes:
 * http_redirect_count: [Integer]
 
   Maximum number of http redirects to follow.
+  Set to `0` to disable following redirects entirely.
+  Default: `10`
+
+* allow_hosts: [String | Array<String>]
+
+  Optional allow-list of host names that may be contacted. It is applied both to the
+  supplied url and to every redirect that is followed; a request to any other host raises
+  `IOStreams::Errors::CommunicationsFailure`.
+  Default: `nil` (any host is allowed).
+
+* maximum_file_size: [Integer]
+
+  Optional maximum number of bytes to download. When the response body exceeds this size the
+  download is aborted with an `IOStreams::Errors::CommunicationsFailure`.
+  Default: `nil` (no limit).
 
 ~~~ruby 
 path = IOStreams.path("http://hostname/path/example.csv")
 ~~~
+
+#### Security: untrusted URLs (SSRF)
+
+Reading an HTTP(S) path causes the application to issue a request to the host named in the url.
+When the url, or any part of it, can be influenced by untrusted input, an attacker can point it
+at internal services or cloud metadata endpoints (Server Side Request Forgery).
+
+Because redirect targets are chosen by the remote server, validating only the url that is passed
+in is not sufficient: a trusted (or compromised) server can redirect the request to an internal
+address. IOStreams provides a few controls to reduce this exposure:
+
+* Restrict which hosts may be contacted, including across redirects:
+
+~~~ruby
+IOStreams.path("https://supplier.example.com/report.csv", allow_hosts: ["supplier.example.com"]).read
+~~~
+
+* Disable redirects entirely for untrusted urls:
+
+~~~ruby
+IOStreams.path(untrusted_url, http_redirect_count: 0).read
+~~~
+
+* Cap the download size to avoid unbounded (denial of service) responses:
+
+~~~ruby
+IOStreams.path(untrusted_url, maximum_file_size: 50 * 1024 * 1024).read
+~~~
+
+Basic authentication credentials are only ever sent to the original host. They are not resent
+when a redirect points at a different scheme, host, or port, so a redirect cannot leak them to
+another server. For stronger guarantees, route these downloads through an egress proxy or network
+policy that blocks private, loopback, and link-local (cloud metadata) addresses.
 
 Similarly when using https:
 

--- a/docs/pgp.md
+++ b/docs/pgp.md
@@ -266,6 +266,43 @@ Now try to read the file:
 IOStreams.join("test/sample.pgp", root: :downloads).read
 ~~~
 
+#### Trust level
+
+The key is imported and then marked as trusted so that GPG will encrypt to it without prompting.
+The trust level can be controlled with the `import_and_trust_level` option:
+
+~~~ruby
+path = IOStreams.join("test/sample.pgp", root: :downloads)
+path.option(:pgp, import_and_trust_key: public_pgp_key, import_and_trust_level: 4)
+path.write("Hello World")
+~~~
+
+Or by calling `IOStreams::Pgp.import_and_trust` directly with the `trust_level` argument:
+
+~~~ruby
+IOStreams::Pgp.import_and_trust(key: public_pgp_key, trust_level: 4)
+~~~
+
+The available levels are the same as those used by `IOStreams::Pgp.set_trust`:
+
+| Level | Meaning                  |
+|:------|:-------------------------|
+| 1     | Undefined (no opinion)   |
+| 2     | Never (do not trust)     |
+| 3     | Marginal                 |
+| 4     | Full                     |
+| 5     | Ultimate (default)       |
+
+> **Security warning**
+>
+> Only import and trust keys that were received from a verified, trusted source.
+>
+> The default trust level is `5` (Ultimate), which tells GPG to treat the imported key as
+> if it were one of your own keys: it becomes implicitly valid and can in turn confer
+> validity on other keys that it has signed. Importing an attacker supplied key at this
+> level allows that attacker to impersonate other recipients. When a key cannot be fully
+> verified, supply a lower `trust_level`.
+
 #### Compression:
 
 The compression used by pgp can be specified by suppling the `:compress` option.

--- a/lib/io_streams/paths/http.rb
+++ b/lib/io_streams/paths/http.rb
@@ -26,7 +26,32 @@ module IOStreams
       #
       #   http_redirect_count: [Integer]
       #     Maximum number of http redirects to follow.
-      def initialize(url, username: nil, password: nil, http_redirect_count: 10, parameters: nil)
+      #     Set to 0 to disable following redirects entirely.
+      #     Default: 10
+      #
+      #   allow_hosts: [String | Array<String>]
+      #     Optional allow-list of host names that may be contacted, applied to the
+      #     supplied url and to every redirect that is followed.
+      #     When supplied, a request to any other host raises CommunicationsFailure.
+      #     Use this to limit Server Side Request Forgery (SSRF) exposure when the url
+      #     can be influenced by untrusted input.
+      #     Default: nil (any host is allowed).
+      #
+      #   maximum_file_size: [Integer]
+      #     Optional maximum number of bytes to download.
+      #     When the response body exceeds this size the download is aborted with a
+      #     CommunicationsFailure, protecting against unbounded (denial of service) responses.
+      #     Default: nil (no limit).
+      #
+      # Security notes:
+      # - Redirect targets are supplied by the remote server. Validating only the url that is
+      #   passed in is therefore not sufficient to prevent SSRF: use `allow_hosts` (or disable
+      #   redirects with `http_redirect_count: 0`) when the url is not fully trusted.
+      # - Basic authentication credentials are only sent to the original host. They are not
+      #   resent when a redirect points at a different scheme, host, or port, so that a
+      #   redirect cannot leak the credentials to another server.
+      def initialize(url, username: nil, password: nil, http_redirect_count: 10, parameters: nil,
+                     allow_hosts: nil, maximum_file_size: nil)
         uri = URI.parse(url)
         unless %w[http https].include?(uri.scheme)
           raise(
@@ -38,6 +63,8 @@ module IOStreams
         @username            = username || uri.user
         @password            = password || uri.password
         @http_redirect_count = http_redirect_count
+        @allow_hosts         = allow_hosts.nil? ? nil : Array(allow_hosts)
+        @maximum_file_size   = maximum_file_size
         @url                 = parameters ? "#{url}?#{URI.encode_www_form(parameters)}" : url
         super(uri.path)
       end
@@ -52,6 +79,8 @@ module IOStreams
       end
 
       private
+
+      attr_reader :allow_hosts, :maximum_file_size
 
       # Read a file using an http get.
       #
@@ -70,11 +99,13 @@ module IOStreams
       def handle_redirects(uri, http_redirect_count, &block)
         uri    = URI.parse(uri) unless uri.is_a?(URI)
         result = nil
-        raise(IOStreams::Errors::CommunicationsFailure, "Too many redirects") if http_redirect_count < 1
+
+        validate_uri!(uri)
 
         Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") do |http|
           request = Net::HTTP::Get.new(uri)
-          request.basic_auth(username, password) if username
+          # Only send credentials to the original host to avoid leaking them via a redirect.
+          request.basic_auth(username, password) if username && same_origin?(uri)
 
           http.request(request) do |response|
             raise(IOStreams::Errors::CommunicationsFailure, "Invalid URL: #{uri}") if response.is_a?(Net::HTTPNotFound)
@@ -83,7 +114,13 @@ module IOStreams
             end
 
             if response.is_a?(Net::HTTPRedirection)
-              new_uri = response["location"]
+              raise(IOStreams::Errors::CommunicationsFailure, "Too many redirects") if http_redirect_count < 1
+
+              location = response["location"]
+              raise(IOStreams::Errors::CommunicationsFailure, "Redirect missing location header: #{uri}") unless location
+
+              # Resolve relative redirects against the current uri.
+              new_uri = uri.merge(location)
               return handle_redirects(new_uri, http_redirect_count - 1, &block)
             end
 
@@ -93,13 +130,49 @@ module IOStreams
 
             # Since Net::HTTP download only supports a push stream, write it to a tempfile first.
             Utils.temp_file_name("iostreams_http") do |file_name|
-              ::File.open(file_name, "wb") { |io| response.read_body { |chunk| io.write(chunk) } }
+              download_to_file(response, file_name)
               # Return a read stream
               result = ::File.open(file_name, "rb") { |io| builder.reader(io, &block) }
             end
           end
         end
         result
+      end
+
+      # Validate that the host may be contacted, and that the scheme is still http(s)
+      # after following a redirect.
+      def validate_uri!(uri)
+        unless %w[http https].include?(uri.scheme)
+          raise(IOStreams::Errors::CommunicationsFailure, "Invalid redirect, only http and https are supported: #{uri}")
+        end
+        return if allow_hosts.nil? || allow_hosts.include?(uri.hostname)
+
+        raise(IOStreams::Errors::CommunicationsFailure, "Host not in the allowed list of hosts: #{uri.hostname}")
+      end
+
+      def same_origin?(uri)
+        original = original_uri
+        uri.scheme == original.scheme && uri.hostname == original.hostname && uri.port == original.port
+      end
+
+      def original_uri
+        @original_uri ||= URI.parse(url)
+      end
+
+      def download_to_file(response, file_name)
+        size = 0
+        ::File.open(file_name, "wb") do |io|
+          response.read_body do |chunk|
+            size += chunk.bytesize
+            if maximum_file_size && (size > maximum_file_size)
+              raise(
+                IOStreams::Errors::CommunicationsFailure,
+                "Exceeded maximum allowed download size of #{maximum_file_size} bytes"
+              )
+            end
+            io.write(chunk)
+          end
+        end
       end
     end
   end

--- a/lib/io_streams/paths/sftp.rb
+++ b/lib/io_streams/paths/sftp.rb
@@ -195,7 +195,7 @@ module IOStreams
             # Give time for password to be processed and stdin to be passed to sftp process.
             sleep self.class.sshpass_wait_seconds
 
-            writer.puts "get #{remote_file_name} #{local_file_name}"
+            writer.puts "get #{remote_file_name.inspect} #{local_file_name.inspect}"
             writer.puts "bye"
             writer.close
             out = reader.read.chomp

--- a/lib/io_streams/pgp.rb
+++ b/lib/io_streams/pgp.rb
@@ -339,11 +339,33 @@ module IOStreams
       raise(Pgp::Failure, "GPG Failed importing key: #{err}#{out}")
     end
 
-    # Returns [String] email for the supplied after importing and trusting the key
+    # Imports the supplied key and then marks it as trusted at the supplied trust level.
+    #
+    # Returns [String] email for the supplied key, or its key id when no email is present.
+    #
+    # key: [String]
+    #   The public (or private) key to import and trust.
+    #
+    # trust_level: [Integer]
+    #   The owner-trust level to assign to the imported key, the same levels used by `set_trust`:
+    #     1 : Undefined  (no opinion)
+    #     2 : Never      (do not trust)
+    #     3 : Marginal
+    #     4 : Full
+    #     5 : Ultimate
+    #   Default: 5 : Ultimate
+    #
+    # SECURITY WARNING:
+    #   Only import and trust keys received from a verified, trusted source.
+    #   The default trust level is `5` (Ultimate), which tells GPG to treat the imported key
+    #   as if it were one of your own keys. An ultimately trusted key is implicitly valid and
+    #   can in turn confer validity on other keys it has signed. Importing an attacker supplied
+    #   key at this level allows that attacker to impersonate other recipients.
+    #   When the key cannot be fully verified, supply a lower `trust_level`.
     #
     # Notes:
     # - If the same email address has multiple keys then only the first is currently trusted.
-    def self.import_and_trust(key:)
+    def self.import_and_trust(key:, trust_level: 5)
       raise(ArgumentError, "Key cannot be empty") if key.nil? || (key == "")
 
       key_info = key_info(key: key).last
@@ -353,7 +375,7 @@ module IOStreams
       raise(ArgumentError, "Recipient email or key id cannot be extracted from supplied key") unless email || key_id
 
       import(key: key)
-      set_trust(email: email, key_id: key_id)
+      set_trust(email: email, key_id: key_id, level: trust_level)
       email || key_id
     end
 
@@ -363,7 +385,23 @@ module IOStreams
     # Returns nil if the email was not found
     #
     # After importing keys, they are not trusted and the relevant trust level must be set.
+    #
+    # level: [Integer]
+    #   The owner-trust level to assign to the key:
+    #     1 : Undefined  (no opinion)
+    #     2 : Never      (do not trust)
+    #     3 : Marginal
+    #     4 : Full
+    #     5 : Ultimate
     #   Default: 5 : Ultimate
+    #
+    # SECURITY WARNING:
+    #   Only trust keys received from a verified, trusted source.
+    #   The default trust level is `5` (Ultimate), which tells GPG to treat the key
+    #   as if it were one of your own keys. An ultimately trusted key is implicitly valid and
+    #   can in turn confer validity on other keys it has signed. Trusting an attacker supplied
+    #   key at this level allows that attacker to impersonate other recipients.
+    #   When the key cannot be fully verified, supply a lower `level`.
     def self.set_trust(email: nil, key_id: nil, level: 5)
       version_check
       fingerprint = key_id || fingerprint(email: email)
@@ -385,7 +423,7 @@ module IOStreams
       command = gpg_command("--list-keys", "--fingerprint", "--with-colons", email.to_s)
       Open3.popen2e(*command) do |_stdin, out, waith_thr|
         output = out.read.chomp
-        if !waith_thr.value.success? && !(output !~ /(public key not found|No public key)/i)
+        if !waith_thr.value.success? && output !~ /(public key not found|No public key)/i
           raise(Pgp::Failure, "GPG Failed calling #{executable} to list keys for #{email}: #{output}")
         end
 

--- a/lib/io_streams/pgp.rb
+++ b/lib/io_streams/pgp.rb
@@ -1,4 +1,5 @@
 require "open3"
+require "shellwords"
 module IOStreams
   # Read/Write PGP/GPG file or stream.
   #
@@ -24,6 +25,18 @@ module IOStreams
     end
 
     @executable = "gpg"
+
+    # Returns [Array<String>] the argv used to invoke gpg, with the supplied
+    # arguments appended.
+    #
+    # All gpg invocations are run without a shell (the multi-argument form of
+    # `Open3`) so that values such as email addresses, key ids, passphrases and
+    # file names cannot be interpreted as shell commands. The configured
+    # `executable` is split with `Shellwords` so that it may still contain
+    # additional fixed arguments (for example "gpg --homedir /path").
+    def self.gpg_command(*args)
+      Shellwords.split(executable) + args.map(&:to_s)
+    end
 
     # Generate a new ultimate trusted local public and private key.
     #
@@ -56,6 +69,12 @@ module IOStreams
                           subkey_length: key_length,
                           expire_date: nil)
       version_check
+
+      # Reject newlines so that a value cannot inject additional directives into
+      # the gpg batch key-generation parameter file.
+      reject_newlines!(name: name, email: email, comment: comment, passphrase: passphrase,
+                       key_type: key_type, subkey_type: subkey_type, expire_date: expire_date)
+
       params = ""
       params << "Key-Type: #{key_type}\n" if key_type
       params << "Key-Length: #{key_length}\n" if key_length
@@ -67,10 +86,11 @@ module IOStreams
       params << "Expire-Date: #{expire_date}\n" if expire_date
       params << "Passphrase: #{passphrase}\n" if passphrase
       params << "%commit"
-      command = "#{executable} --batch --gen-key --no-tty"
+      command = gpg_command("--batch", "--gen-key", "--no-tty")
 
-      out, err, status = Open3.capture3(command, binmode: true, stdin_data: params)
-      logger&.debug { "IOStreams::Pgp.generate_key: #{command}\n#{params}\n#{err}#{out}" }
+      out, err, status = Open3.capture3(*command, binmode: true, stdin_data: params)
+      # Do not log `params`, it contains the passphrase.
+      logger&.debug { "IOStreams::Pgp.generate_key: #{command.shelljoin}\n#{err}#{out}" }
 
       raise(Pgp::Failure, "GPG Failed to generate key: #{err}#{out}") unless status.success?
 
@@ -130,11 +150,12 @@ module IOStreams
     # Returns [] if no keys were found.
     def self.list_keys(email: nil, key_id: nil, private: false)
       version_check
-      cmd     = private ? "--list-secret-keys" : "--list-keys"
-      command = "#{executable} #{cmd} #{email || key_id}"
+      args = [private ? "--list-secret-keys" : "--list-keys"]
+      args << (email || key_id).to_s if email || key_id
+      command = gpg_command(*args)
 
-      out, err, status = Open3.capture3(command, binmode: true)
-      logger&.debug { "IOStreams::Pgp.list_keys: #{command}\n#{err}#{out}" }
+      out, err, status = Open3.capture3(*command, binmode: true)
+      logger&.debug { "IOStreams::Pgp.list_keys: #{command.shelljoin}\n#{err}#{out}" }
       if status.success? && out.length.positive?
         parse_list_output(out)
       else
@@ -158,10 +179,10 @@ module IOStreams
     #     email:      [String]
     def self.key_info(key:)
       version_check
-      command = "#{executable} --batch --no-tty"
+      command = gpg_command("--batch", "--no-tty")
 
-      out, err, status = Open3.capture3(command, binmode: true, stdin_data: key)
-      logger&.debug { "IOStreams::Pgp.key_info: #{command}\n#{err}#{out}" }
+      out, err, status = Open3.capture3(*command, binmode: true, stdin_data: key)
+      logger&.debug { "IOStreams::Pgp.key_info: #{command.shelljoin}\n#{err}#{out}" }
 
       # Try parsing even if we get an error - some versions of GPG return non-zero status but still output key info
       unless (status.success? || err.include?("key ID") || out.include?("pub")) && out.length.positive?
@@ -186,16 +207,18 @@ module IOStreams
     def self.export(email:, ascii: true, private: false, passphrase: nil)
       version_check
 
-      command = "#{executable} "
-      command << "--pinentry-mode loopback " if pgp_version.to_f >= 2.1
-      command << "--no-symkey-cache " if pgp_version.to_f >= 2.4
-      command << "--armor " if ascii
-      command << "--no-tty  --batch --passphrase"
-      command << (passphrase ? " #{passphrase} " : "-fd 0 ")
-      command << (private ? "--export-secret-keys #{email}" : "--export #{email}")
+      args = []
+      args += ["--pinentry-mode", "loopback"] if pgp_version.to_f >= 2.1
+      args << "--no-symkey-cache" if pgp_version.to_f >= 2.4
+      args << "--armor" if ascii
+      args += ["--no-tty", "--batch"]
+      args += passphrase ? ["--passphrase", passphrase] : ["--passphrase-fd", "0"]
+      args += private ? ["--export-secret-keys", email.to_s] : ["--export", email.to_s]
+      command = gpg_command(*args)
 
-      out, err, status = Open3.capture3(command, binmode: true)
-      logger&.debug { "IOStreams::Pgp.export: #{command}\n#{err}" }
+      out, err, status = Open3.capture3(*command, binmode: true)
+      # Do not log the command, it may contain the passphrase.
+      logger&.debug { "IOStreams::Pgp.export: #{email}\n#{err}" }
 
       raise(Pgp::Failure, "GPG Failed reading key: #{email}: #{err}") unless status.success? && out.length.positive?
 
@@ -219,10 +242,10 @@ module IOStreams
     # * Invalidated keys must be removed manually.
     def self.import(key:)
       version_check
-      command = "#{executable} --batch --import"
+      command = gpg_command("--batch", "--import")
 
-      out, err, status = Open3.capture3(command, binmode: true, stdin_data: key)
-      logger&.debug { "IOStreams::Pgp.import: #{command}\n#{err}#{out}" }
+      out, err, status = Open3.capture3(*command, binmode: true, stdin_data: key)
+      logger&.debug { "IOStreams::Pgp.import: #{command.shelljoin}\n#{err}#{out}" }
 
       # Handle both old and new versions of GPG
       # For older versions, the output is in err, for newer ones it might be in out
@@ -346,10 +369,10 @@ module IOStreams
       fingerprint = key_id || fingerprint(email: email)
       return unless fingerprint
 
-      command          = "#{executable} --import-ownertrust"
+      command          = gpg_command("--import-ownertrust")
       trust            = "#{fingerprint}:#{level + 1}:\n"
-      out, err, status = Open3.capture3(command, stdin_data: trust)
-      logger&.debug { "IOStreams::Pgp.set_trust: #{command}\n#{err}#{out}" }
+      out, err, status = Open3.capture3(*command, stdin_data: trust)
+      logger&.debug { "IOStreams::Pgp.set_trust: #{command.shelljoin}\n#{err}#{out}" }
 
       raise(Pgp::Failure, "GPG Failed trusting key: #{err} #{out}") unless status.success?
 
@@ -359,7 +382,8 @@ module IOStreams
     # DEPRECATED - Use key_ids instead of fingerprints
     def self.fingerprint(email:)
       version_check
-      Open3.popen2e("#{executable} --list-keys --fingerprint --with-colons #{email}") do |_stdin, out, waith_thr|
+      command = gpg_command("--list-keys", "--fingerprint", "--with-colons", email.to_s)
+      Open3.popen2e(*command) do |_stdin, out, waith_thr|
         output = out.read.chomp
         if !waith_thr.value.success? && !(output !~ /(public key not found|No public key)/i)
           raise(Pgp::Failure, "GPG Failed calling #{executable} to list keys for #{email}: #{output}")
@@ -381,9 +405,9 @@ module IOStreams
     # Returns [String] the version of pgp currently installed
     def self.pgp_version
       @pgp_version ||= begin
-        command          = "#{executable} --version"
-        out, err, status = Open3.capture3(command)
-        logger&.debug { "IOStreams::Pgp.version: #{command}\n#{err}#{out}" }
+        command          = gpg_command("--version")
+        out, err, status = Open3.capture3(*command)
+        logger&.debug { "IOStreams::Pgp.version: #{command.shelljoin}\n#{err}#{out}" }
         if status.success?
           # Sample output
           #   #{executable} (GnuPG) 2.0.30
@@ -507,6 +531,13 @@ module IOStreams
       results
     end
 
+    def self.reject_newlines!(**fields)
+      fields.each_pair do |field, value|
+        next if value.nil?
+        raise(ArgumentError, "IOStreams::Pgp.generate_key: :#{field} cannot contain newlines") if value.to_s =~ /[\r\n]/
+      end
+    end
+
     def self.delete_public_or_private_keys(email: nil, key_id: nil, private: false)
       keys = private ? "secret-keys" : "keys"
 
@@ -517,9 +548,9 @@ module IOStreams
         key_id = key_info[:key_id]
         next unless key_id
 
-        command          = "#{executable} --batch --no-tty --yes --delete-#{keys} #{key_id}"
-        out, err, status = Open3.capture3(command, binmode: true)
-        logger&.debug { "IOStreams::Pgp.delete_keys: #{command}\n#{err}#{out}" }
+        command          = gpg_command("--batch", "--no-tty", "--yes", "--delete-#{keys}", key_id)
+        out, err, status = Open3.capture3(*command, binmode: true)
+        logger&.debug { "IOStreams::Pgp.delete_keys: #{command.shelljoin}\n#{err}#{out}" }
 
         unless status.success?
           raise(Pgp::Failure, "GPG Failed calling #{executable} to delete #{keys} for #{email || key_id}: #{err}: #{out}")
@@ -532,18 +563,27 @@ module IOStreams
     def self.delete_public_or_private_keys_v1(email: nil, key_id: nil, private: false)
       keys = private ? "secret-keys" : "keys"
 
-      command = "for i in `#{executable} --list-#{keys} --with-colons --fingerprint #{email || key_id} | grep \"^fpr\" | cut -d: -f10`; do\n"
-      command << "#{executable} --batch --no-tty --yes --delete-#{keys} \"$i\" ;\n"
-      command << "done"
+      # List the fingerprints, then delete each one. Previously this shelled out
+      # to a `for` loop, which allowed shell injection via :email / :key_id.
+      list_command        = gpg_command("--list-#{keys}", "--with-colons", "--fingerprint", (email || key_id).to_s)
+      list_out, list_err, = Open3.capture3(*list_command, binmode: true)
+      logger&.debug { "IOStreams::Pgp.delete_keys: #{list_command.shelljoin}\n#{list_err}: #{list_out}" }
 
-      out, err, status = Open3.capture3(command, binmode: true)
-      logger&.debug { "IOStreams::Pgp.delete_keys: #{command}\n#{err}: #{out}" }
+      return false if list_err =~ /(not found|no public key)/i
 
-      return false if err =~ /(not found|no public key)/i
-      unless status.success?
-        raise(Pgp::Failure, "GPG Failed calling #{executable} to delete #{keys} for #{email || key_id}: #{err}: #{out}")
+      fingerprints = list_out.each_line.select { |line| line.start_with?("fpr") }.map { |line| line.split(":")[9] }.compact
+      return false if fingerprints.empty?
+
+      fingerprints.each do |fingerprint|
+        command          = gpg_command("--batch", "--no-tty", "--yes", "--delete-#{keys}", fingerprint)
+        out, err, status = Open3.capture3(*command, binmode: true)
+        logger&.debug { "IOStreams::Pgp.delete_keys: #{command.shelljoin}\n#{err}: #{out}" }
+
+        unless status.success?
+          raise(Pgp::Failure, "GPG Failed calling #{executable} to delete #{keys} for #{email || key_id}: #{err}: #{out}")
+        end
+        raise(Pgp::Failure, "GPG Failed to delete #{keys} for #{email || key_id} #{err.strip}: #{out}") if out.include?("error")
       end
-      raise(Pgp::Failure, "GPG Failed to delete #{keys} for #{email || key_id} #{err.strip}: #{out}") if out.include?("error")
 
       true
     end

--- a/lib/io_streams/pgp/reader.rb
+++ b/lib/io_streams/pgp/reader.rb
@@ -26,17 +26,18 @@ module IOStreams
         passphrase ||= default_passphrase
         raise(ArgumentError, "Missing both passphrase and IOStreams::Pgp::Reader.default_passphrase") unless passphrase
 
+        args = []
         # Use --pinentry-mode loopback for all GnuPG versions >= 2.1
-        loopback = IOStreams::Pgp.pgp_version.to_f >= 2.1 ? "--pinentry-mode loopback" : ""
-
+        args += ["--pinentry-mode", "loopback"] if IOStreams::Pgp.pgp_version.to_f >= 2.1
         # Use --no-symkey-cache for GnuPG versions >= 2.4 to avoid caching session keys
-        no_symkey_cache = IOStreams::Pgp.pgp_version.to_f >= 2.4 ? "--no-symkey-cache" : ""
+        args << "--no-symkey-cache" if IOStreams::Pgp.pgp_version.to_f >= 2.4
+        args += ["--batch", "--no-tty", "--yes", "--decrypt", "--passphrase-fd", "0", file_name.to_s]
 
-        command  = "#{IOStreams::Pgp.executable} #{loopback} #{no_symkey_cache} --batch --no-tty --yes --decrypt --passphrase-fd 0 #{file_name}"
-        IOStreams::Pgp.logger&.debug { "IOStreams::Pgp::Reader.open: #{command}" }
+        command = IOStreams::Pgp.gpg_command(*args)
+        IOStreams::Pgp.logger&.debug { "IOStreams::Pgp::Reader.open: #{command.shelljoin}" }
 
         # Read decrypted contents from stdout
-        Open3.popen3(command) do |stdin, stdout, stderr, waith_thr|
+        Open3.popen3(*command) do |stdin, stdout, stderr, waith_thr|
           stdin.puts(passphrase) if passphrase
           stdin.close
           result =

--- a/lib/io_streams/pgp/writer.rb
+++ b/lib/io_streams/pgp/writer.rb
@@ -38,6 +38,23 @@ module IOStreams
       #   One or more pgp keys to import and then use to encrypt the file.
       #   Note: Ascii Keys can contain multiple keys, only the last one in the file is used.
       #
+      # import_and_trust_level: [Integer]
+      #   The owner-trust level to assign to keys supplied via :import_and_trust_key.
+      #     1 : Undefined  (no opinion)
+      #     2 : Never      (do not trust)
+      #     3 : Marginal
+      #     4 : Full
+      #     5 : Ultimate
+      #   Default: 5 : Ultimate
+      #
+      #   SECURITY WARNING:
+      #     Only import and trust keys received from a verified, trusted source.
+      #     The default trust level is `5` (Ultimate), which tells GPG to treat the imported key
+      #     as if it were one of your own keys. An ultimately trusted key is implicitly valid and
+      #     can in turn confer validity on other keys it has signed. Importing an attacker supplied
+      #     key at this level allows that attacker to impersonate other recipients.
+      #     When the key cannot be fully verified, supply a lower `import_and_trust_level`.
+      #
       # signer: [String]
       #   Name of user with which to sign the encypted file.
       #   Default: default_signer or do not sign.
@@ -58,6 +75,7 @@ module IOStreams
       def self.file(file_name,
                     recipient: nil,
                     import_and_trust_key: nil,
+                    import_and_trust_level: 5,
                     signer: default_signer,
                     signer_passphrase: default_signer_passphrase,
                     compress: :zip,
@@ -75,7 +93,7 @@ module IOStreams
         recipients << audit_recipient if audit_recipient
 
         Array(import_and_trust_key).each do |key|
-          recipients << IOStreams::Pgp.import_and_trust(key: key)
+          recipients << IOStreams::Pgp.import_and_trust(key: key, trust_level: import_and_trust_level)
         end
 
         # Write to stdin, with encrypted contents being written to the file

--- a/lib/io_streams/pgp/writer.rb
+++ b/lib/io_streams/pgp/writer.rb
@@ -79,22 +79,24 @@ module IOStreams
         end
 
         # Write to stdin, with encrypted contents being written to the file
-        command = "#{IOStreams::Pgp.executable} --batch --no-tty --yes --encrypt"
-        command << " --sign --local-user \"#{signer}\"" if signer
+        args = ["--batch", "--no-tty", "--yes", "--encrypt"]
+        args += ["--sign", "--local-user", signer.to_s] if signer
         if signer_passphrase
-          command << " --pinentry-mode loopback" if IOStreams::Pgp.pgp_version.to_f >= 2.1
-          command << " --no-symkey-cache" if IOStreams::Pgp.pgp_version.to_f >= 2.4
-          command << " --passphrase \"#{signer_passphrase}\""
+          args += ["--pinentry-mode", "loopback"] if IOStreams::Pgp.pgp_version.to_f >= 2.1
+          args << "--no-symkey-cache" if IOStreams::Pgp.pgp_version.to_f >= 2.4
+          args += ["--passphrase", signer_passphrase.to_s]
         end
-        command << " -z #{compress_level}" if compress_level != 6
-        command << " --compress-algo #{compress}" unless compress == :none
-        recipients.each { |address| command << " --recipient \"#{address}\"" }
-        command << " -o \"#{file_name}\""
+        args += ["-z", compress_level.to_s] if compress_level != 6
+        args += ["--compress-algo", compress.to_s] unless compress == :none
+        recipients.each { |address| args += ["--recipient", address.to_s] }
+        args += ["-o", file_name.to_s]
+        command = IOStreams::Pgp.gpg_command(*args)
 
-        IOStreams::Pgp.logger&.debug { "IOStreams::Pgp::Writer.open: #{command}" }
+        # Do not log the command, it may contain the signer passphrase.
+        IOStreams::Pgp.logger&.debug { "IOStreams::Pgp::Writer.open: encrypt -o #{file_name}" }
 
         result = nil
-        Open3.popen2e(command) do |stdin, out, waith_thr|
+        Open3.popen2e(*command) do |stdin, out, waith_thr|
           begin
             stdin.binmode
             result = yield(stdin)

--- a/lib/io_streams/zip/writer.rb
+++ b/lib/io_streams/zip/writer.rb
@@ -20,6 +20,16 @@ module IOStreams
       #     Default: "file"
       #
       # The stream supplied to the block only responds to #write
+      #
+      # Note:
+      #   This writer uses `zip_tricks` rather than `rubyzip` on purpose. `rubyzip`'s
+      #   `Zip::OutputStream` requires a seekable output: it seeks back to rewrite each
+      #   entry's local header with the CRC and sizes once the entry is finished. That
+      #   means it cannot write directly to a non-seekable destination (S3, SFTP, HTTP,
+      #   a socket); the output would first have to be spooled to a temporary file and
+      #   then copied across. `zip_tricks` streams to non-seekable outputs by emitting
+      #   data descriptors instead, so we can write straight to the output stream and
+      #   avoid the temp file round-trip.
       def self.stream(output_stream, zip_file_name: nil, entry_file_name: zip_file_name)
         entry_file_name ||= "file"
 

--- a/test/paths/http_test.rb
+++ b/test/paths/http_test.rb
@@ -30,7 +30,8 @@ module Paths
 
       # Build a raw HTTP response string.
       def self.response(status, body: "", headers: {})
-        reason = {200 => "OK", 302 => "Found", 401 => "Unauthorized", 404 => "Not Found"}[status]
+        reason = {200 => "OK", 302 => "Found", 401 => "Unauthorized", 404 => "Not Found",
+                  500 => "Internal Server Error"}[status]
         all    = {"Content-Length" => body.bytesize.to_s, "Connection" => "close"}.merge(headers)
         lines  = ["HTTP/1.1 #{status} #{reason}"]
         all.each { |key, value| lines << "#{key}: #{value}" }
@@ -68,6 +69,15 @@ module Paths
     end
 
     describe IOStreams::Paths::HTTP do
+      describe ".new" do
+        it "rejects a non-http(s) scheme" do
+          error = assert_raises ArgumentError do
+            IOStreams::Paths::HTTP.new("ftp://example.com/file")
+          end
+          assert_includes error.message, "Invalid URL"
+        end
+      end
+
       describe ".open (live)" do
         let(:url) { "http://google.com" }
         let(:ssl_url) { "https://google.com" }
@@ -108,6 +118,42 @@ module Paths
           assert_equal body, IOStreams::Paths::HTTP.new("#{@server.base_url}/file").read
         end
 
+        it "raises when the server returns 404 Not Found" do
+          start_server { |_path| TestHTTPServer.response(404) }
+
+          error = assert_raises IOStreams::Errors::CommunicationsFailure do
+            IOStreams::Paths::HTTP.new("#{@server.base_url}/missing").read
+          end
+          assert_includes error.message, "Invalid URL"
+        end
+
+        it "raises when the server requires authorization" do
+          start_server { |_path| TestHTTPServer.response(401) }
+
+          error = assert_raises IOStreams::Errors::CommunicationsFailure do
+            IOStreams::Paths::HTTP.new("#{@server.base_url}/file").read
+          end
+          assert_includes error.message, "Authorization Required"
+        end
+
+        it "raises on an unsuccessful response code" do
+          start_server { |_path| TestHTTPServer.response(500) }
+
+          error = assert_raises IOStreams::Errors::CommunicationsFailure do
+            IOStreams::Paths::HTTP.new("#{@server.base_url}/file").read
+          end
+          assert_includes error.message, "Invalid response code: 500"
+        end
+
+        it "appends supplied parameters to the url as a query string" do
+          start_server { |_path| TestHTTPServer.response(200, body: body) }
+
+          IOStreams::Paths::HTTP.new("#{@server.base_url}/file", parameters: {q: "search term", page: 2}).read
+          path = @server.requests.first[:path]
+          assert_includes path, "q=search+term"
+          assert_includes path, "page=2"
+        end
+
         it "follows a relative redirect" do
           start_server do |path|
             if path == "/redirect"
@@ -134,6 +180,26 @@ module Paths
           assert_raises IOStreams::Errors::CommunicationsFailure do
             IOStreams::Paths::HTTP.new("#{@server.base_url}/file", http_redirect_count: 0).read
           end
+        end
+
+        it "raises when a redirect is missing the location header" do
+          start_server { |_path| TestHTTPServer.response(302) }
+
+          error = assert_raises IOStreams::Errors::CommunicationsFailure do
+            IOStreams::Paths::HTTP.new("#{@server.base_url}/redirect").read
+          end
+          assert_includes error.message, "missing location"
+        end
+
+        it "rejects a redirect to a host outside the allow list" do
+          # The initial host is allowed, but the server redirects to a different
+          # host name (localhost) that is not, which is the core SSRF scenario.
+          start_server { |_path| TestHTTPServer.response(302, headers: {"Location" => "http://localhost:#{@server.port}/file"}) }
+
+          error = assert_raises IOStreams::Errors::CommunicationsFailure do
+            IOStreams::Paths::HTTP.new("#{@server.base_url}/redirect", allow_hosts: ["127.0.0.1"]).read
+          end
+          assert_includes error.message, "not in the allowed list"
         end
 
         it "rejects a redirect to a non-http(s) scheme" do
@@ -169,6 +235,18 @@ module Paths
           assert_equal body, IOStreams::Paths::HTTP.new("#{@server.base_url}/file", allow_hosts: ["127.0.0.1"]).read
         end
 
+        it "accepts allow_hosts supplied as a single string" do
+          start_server { |_path| TestHTTPServer.response(200, body: body) }
+
+          assert_equal body, IOStreams::Paths::HTTP.new("#{@server.base_url}/file", allow_hosts: "127.0.0.1").read
+        end
+
+        it "downloads a body that is within the maximum file size" do
+          start_server { |_path| TestHTTPServer.response(200, body: body) }
+
+          assert_equal body, IOStreams::Paths::HTTP.new("#{@server.base_url}/file", maximum_file_size: body.bytesize).read
+        end
+
         it "sends basic auth credentials to the original host" do
           start_server { |_path| TestHTTPServer.response(200, body: body) }
 
@@ -188,6 +266,23 @@ module Paths
           refute_nil @server.requests.first[:headers]["authorization"]
           # But not leaked to the redirect target.
           assert_nil @other.requests.first[:headers]["authorization"]
+        end
+
+        it "resends credentials across a same-origin redirect" do
+          start_server do |path|
+            if path == "/redirect"
+              TestHTTPServer.response(302, headers: {"Location" => "/file"})
+            else
+              TestHTTPServer.response(200, body: body)
+            end
+          end
+
+          result = IOStreams::Paths::HTTP.new("#{@server.base_url}/redirect", username: "jack", password: "secret").read
+          assert_equal body, result
+
+          # Same scheme, host and port, so credentials are sent on both requests.
+          assert_equal 2, @server.requests.size
+          assert(@server.requests.all? { |request| request[:headers]["authorization"] })
         end
       end
     end

--- a/test/paths/http_test.rb
+++ b/test/paths/http_test.rb
@@ -1,17 +1,77 @@
 require_relative "../test_helper"
+require "socket"
+require "base64"
 
 module Paths
   class HTTPTest < Minitest::Test
+    # Minimal HTTP server used to exercise redirect, credential, allow-list and
+    # download-size handling without depending on an external service.
+    class TestHTTPServer
+      attr_reader :port, :requests
+
+      def initialize(&handler)
+        @handler  = handler
+        @requests = []
+        @server   = TCPServer.new("127.0.0.1", 0)
+        @port     = @server.addr[1]
+        @thread   = Thread.new { serve }
+      end
+
+      def base_url
+        "http://127.0.0.1:#{port}"
+      end
+
+      def shutdown
+        @thread&.kill
+        @server&.close
+      rescue StandardError
+        nil
+      end
+
+      # Build a raw HTTP response string.
+      def self.response(status, body: "", headers: {})
+        reason = {200 => "OK", 302 => "Found", 401 => "Unauthorized", 404 => "Not Found"}[status]
+        all    = {"Content-Length" => body.bytesize.to_s, "Connection" => "close"}.merge(headers)
+        lines  = ["HTTP/1.1 #{status} #{reason}"]
+        all.each { |key, value| lines << "#{key}: #{value}" }
+        lines << ""
+        lines << body
+        lines.join("\r\n")
+      end
+
+      private
+
+      def serve
+        loop do
+          client = @server.accept
+          handle_client(client)
+        end
+      rescue IOError, Errno::EBADF
+        # Server was shut down.
+      end
+
+      def handle_client(client)
+        request_line = client.gets
+        return if request_line.nil?
+
+        method, path, = request_line.split
+        headers = {}
+        while (line = client.gets) && line != "\r\n"
+          key, value                  = line.split(":", 2)
+          headers[key.strip.downcase] = value.to_s.strip
+        end
+        @requests << {method: method, path: path, headers: headers}
+        client.write(@handler.call(path))
+      ensure
+        client&.close
+      end
+    end
+
     describe IOStreams::Paths::HTTP do
-      let :url do
-        "http://google.com"
-      end
+      describe ".open (live)" do
+        let(:url) { "http://google.com" }
+        let(:ssl_url) { "https://google.com" }
 
-      let :ssl_url do
-        "https://google.com"
-      end
-
-      describe ".open" do
         it "reads http" do
           result = IOStreams::Paths::HTTP.new(url).read
           assert_includes result, "Google"
@@ -27,6 +87,107 @@ module Paths
             io = StringIO.new
             IOStreams::Paths::HTTP.new(io)
           end
+        end
+      end
+
+      describe "with a local server" do
+        let(:body) { "Hello World" }
+
+        after do
+          @server&.shutdown
+          @other&.shutdown
+        end
+
+        def start_server(&block)
+          @server = TestHTTPServer.new(&block)
+        end
+
+        it "downloads a file" do
+          start_server { |_path| TestHTTPServer.response(200, body: body) }
+
+          assert_equal body, IOStreams::Paths::HTTP.new("#{@server.base_url}/file").read
+        end
+
+        it "follows a relative redirect" do
+          start_server do |path|
+            if path == "/redirect"
+              TestHTTPServer.response(302, headers: {"Location" => "/file"})
+            else
+              TestHTTPServer.response(200, body: body)
+            end
+          end
+
+          assert_equal body, IOStreams::Paths::HTTP.new("#{@server.base_url}/redirect").read
+        end
+
+        it "raises when too many redirects are followed" do
+          start_server { |_path| TestHTTPServer.response(302, headers: {"Location" => "/loop"}) }
+
+          assert_raises IOStreams::Errors::CommunicationsFailure do
+            IOStreams::Paths::HTTP.new("#{@server.base_url}/loop", http_redirect_count: 2).read
+          end
+        end
+
+        it "does not follow redirects when disabled" do
+          start_server { |_path| TestHTTPServer.response(302, headers: {"Location" => "/file"}) }
+
+          assert_raises IOStreams::Errors::CommunicationsFailure do
+            IOStreams::Paths::HTTP.new("#{@server.base_url}/file", http_redirect_count: 0).read
+          end
+        end
+
+        it "rejects a redirect to a non-http(s) scheme" do
+          start_server { |_path| TestHTTPServer.response(302, headers: {"Location" => "ftp://127.0.0.1/secret"}) }
+
+          error = assert_raises IOStreams::Errors::CommunicationsFailure do
+            IOStreams::Paths::HTTP.new("#{@server.base_url}/redirect").read
+          end
+          assert_includes error.message, "only http and https"
+        end
+
+        it "aborts a download that exceeds the maximum file size" do
+          start_server { |_path| TestHTTPServer.response(200, body: body) }
+
+          error = assert_raises IOStreams::Errors::CommunicationsFailure do
+            IOStreams::Paths::HTTP.new("#{@server.base_url}/file", maximum_file_size: 5).read
+          end
+          assert_includes error.message, "maximum allowed download size"
+        end
+
+        it "rejects a host that is not in the allow list" do
+          start_server { |_path| TestHTTPServer.response(200, body: body) }
+
+          error = assert_raises IOStreams::Errors::CommunicationsFailure do
+            IOStreams::Paths::HTTP.new("#{@server.base_url}/file", allow_hosts: ["example.com"]).read
+          end
+          assert_includes error.message, "not in the allowed list"
+        end
+
+        it "allows a host that is in the allow list" do
+          start_server { |_path| TestHTTPServer.response(200, body: body) }
+
+          assert_equal body, IOStreams::Paths::HTTP.new("#{@server.base_url}/file", allow_hosts: ["127.0.0.1"]).read
+        end
+
+        it "sends basic auth credentials to the original host" do
+          start_server { |_path| TestHTTPServer.response(200, body: body) }
+
+          IOStreams::Paths::HTTP.new("#{@server.base_url}/file", username: "jack", password: "secret").read
+          assert auth = @server.requests.first[:headers]["authorization"]
+          assert_equal %w[jack secret], Base64.decode64(auth.sub(/\ABasic /, "")).split(":")
+        end
+
+        it "does not resend credentials across a redirect to another host" do
+          @other = TestHTTPServer.new { |_path| TestHTTPServer.response(200, body: body) }
+          start_server { |_path| TestHTTPServer.response(302, headers: {"Location" => "#{@other.base_url}/file"}) }
+
+          result = IOStreams::Paths::HTTP.new("#{@server.base_url}/redirect", username: "jack", password: "secret").read
+          assert_equal body, result
+
+          # Credentials sent to the original host.
+          refute_nil @server.requests.first[:headers]["authorization"]
+          # But not leaked to the redirect target.
+          assert_nil @other.requests.first[:headers]["authorization"]
         end
       end
     end

--- a/test/pgp_test.rb
+++ b/test/pgp_test.rb
@@ -263,5 +263,67 @@ class PgpTest < Minitest::Test
         end
       end
     end
+
+    describe ".import_and_trust" do
+      before do
+        @public_key = public_key
+        # There is a timing issue with creating and then deleting keys.
+        # Call list_keys again to give GnuPGP time.
+        IOStreams::Pgp.list_keys(email: email, private: true)
+        IOStreams::Pgp.delete_keys(email: email, public: true, private: true)
+      end
+
+      it "raises when the key is empty" do
+        assert_raises(ArgumentError) { IOStreams::Pgp.import_and_trust(key: "") }
+        assert_raises(ArgumentError) { IOStreams::Pgp.import_and_trust(key: nil) }
+      end
+
+      it "imports and trusts the key, returning the email" do
+        assert_equal email, IOStreams::Pgp.import_and_trust(key: @public_key)
+        # There is a timing issue with creating and then immediately using keys.
+        IOStreams::Pgp.list_keys(email: email)
+        assert key = IOStreams::Pgp.list_keys(email: email).first
+        ver   = IOStreams::Pgp.pgp_version
+        maint = ver.split(".").last.to_i
+        assert_equal "ultimate", key[:trust] if (ver.to_f >= 2) && (maint >= 30)
+      end
+
+      it "defaults the trust level to ultimate (5)" do
+        captured = {}
+        IOStreams::Pgp.stub(:set_trust, ->(**kwargs) { captured = kwargs }) do
+          IOStreams::Pgp.import_and_trust(key: @public_key)
+        end
+        assert_equal 5, captured[:level]
+      end
+
+      it "passes the supplied trust_level through to set_trust" do
+        captured = {}
+        IOStreams::Pgp.stub(:set_trust, ->(**kwargs) { captured = kwargs }) do
+          IOStreams::Pgp.import_and_trust(key: @public_key, trust_level: 4)
+        end
+        assert_equal 4, captured[:level]
+      end
+    end
+
+    describe ".set_trust" do
+      before do
+        generated_key_id
+        # There is a timing issue with creating and then immediately using keys.
+        # Call list_keys again to give GnuPGP time.
+        IOStreams::Pgp.list_keys(email: email)
+      end
+
+      it "returns nil when the key is not found" do
+        assert_nil IOStreams::Pgp.set_trust(email: "random@iostreams.net")
+      end
+
+      it "trusts an existing key" do
+        refute_nil IOStreams::Pgp.set_trust(email: email)
+      end
+
+      it "trusts an existing key at the supplied level" do
+        refute_nil IOStreams::Pgp.set_trust(email: email, level: 4)
+      end
+    end
   end
 end

--- a/test/pgp_test.rb
+++ b/test/pgp_test.rb
@@ -1,4 +1,5 @@
 require_relative "test_helper"
+require "tmpdir"
 
 # Turn on logging if experiencing issues with new versions of gpg
 # require "logger"
@@ -50,6 +51,41 @@ class PgpTest < Minitest::Test
     describe ".generate_key" do
       it "returns the key id" do
         assert generated_key_id
+      end
+
+      # Newlines would otherwise allow extra directives to be injected into the
+      # gpg batch key-generation parameter file.
+      it "rejects newlines in fields to prevent batch directive injection" do
+        %i[name email comment passphrase key_type subkey_type expire_date].each do |field|
+          args        = {name: user_name, email: email, passphrase: passphrase, key_length: 1024}
+          args[field] = "#{args[field]}\nKey-Type: RSA"
+          assert_raises(ArgumentError) { IOStreams::Pgp.generate_key(**args) }
+        end
+      end
+    end
+
+    describe "shell safety" do
+      # All gpg invocations use the multi-argument Open3 form, so no shell is
+      # spawned and embedded shell metacharacters cannot be executed.
+      it "treats shell metacharacters in :email literally without invoking a shell" do
+        Dir.mktmpdir do |dir|
+          marker    = ::File.join(dir, "pwned")
+          malicious = "nobody@iostreams.net; touch #{marker}"
+
+          # No such key exists, so this simply reports the key as absent.
+          refute IOStreams::Pgp.key?(email: malicious)
+          refute ::File.exist?(marker), "Embedded shell command was executed"
+        end
+      end
+
+      it "treats shell metacharacters in :email literally when deleting keys" do
+        Dir.mktmpdir do |dir|
+          marker    = ::File.join(dir, "pwned")
+          malicious = "nobody@iostreams.net; touch #{marker}"
+
+          refute IOStreams::Pgp.delete_keys(email: malicious, public: true, private: true)
+          refute ::File.exist?(marker), "Embedded shell command was executed"
+        end
       end
     end
 
@@ -278,6 +314,22 @@ class PgpTest < Minitest::Test
         assert_raises(ArgumentError) { IOStreams::Pgp.import_and_trust(key: nil) }
       end
 
+      it "returns the key id when the key has no email" do
+        IOStreams::Pgp.stub(:key_info, [{key_id: "ABCDEF1234567890"}]) do
+          IOStreams::Pgp.stub(:import, nil) do
+            IOStreams::Pgp.stub(:set_trust, nil) do
+              assert_equal "ABCDEF1234567890", IOStreams::Pgp.import_and_trust(key: @public_key)
+            end
+          end
+        end
+      end
+
+      it "raises when neither email nor key id can be extracted" do
+        IOStreams::Pgp.stub(:key_info, [{}]) do
+          assert_raises(ArgumentError) { IOStreams::Pgp.import_and_trust(key: @public_key) }
+        end
+      end
+
       it "imports and trusts the key, returning the email" do
         assert_equal email, IOStreams::Pgp.import_and_trust(key: @public_key)
         # There is a timing issue with creating and then immediately using keys.
@@ -321,9 +373,129 @@ class PgpTest < Minitest::Test
         refute_nil IOStreams::Pgp.set_trust(email: email)
       end
 
+      it "trusts an existing key by key_id" do
+        fingerprint = IOStreams::Pgp.fingerprint(email: email)
+        refute_nil IOStreams::Pgp.set_trust(key_id: fingerprint)
+      end
+
       it "trusts an existing key at the supplied level" do
         refute_nil IOStreams::Pgp.set_trust(email: email, level: 4)
       end
+    end
+  end
+
+  # Pure parsing tests against the documented output of several gpg versions.
+  # These exercise `parse_list_output` directly so the supported formats are
+  # verified in CI regardless of which gpg version happens to be installed.
+  describe "IOStreams::Pgp.parse_list_output" do
+    it "parses GnuPG 2.4.x output (fingerprint on its own line, rsa key type)" do
+      output = <<~OUTPUT
+        pub   rsa3072 2023-05-15 [SC] [expires: 2025-05-14]
+              CB3E582C87C4D569C52F4A28C0A5F177F20E39B0
+        uid           [ultimate] Joe Bloggs <pgp_test@iostreams.net>
+        sub   rsa3072 2023-05-15 [E] [expires: 2025-05-14]
+      OUTPUT
+
+      assert_equal 1, (keys = IOStreams::Pgp.parse_list_output(output)).size
+      key = keys.first
+      refute key[:private]
+      assert_equal 3072, key[:key_length]
+      assert_equal "rsa", key[:key_type]
+      assert_equal "CB3E582C87C4D569C52F4A28C0A5F177F20E39B0", key[:key_id]
+      assert_equal Date.new(2023, 5, 15), key[:date]
+      assert_equal "Joe Bloggs", key[:name]
+      assert_equal "pgp_test@iostreams.net", key[:email]
+      assert_equal "ultimate", key[:trust]
+    end
+
+    it "parses GnuPG 2.2.x output" do
+      output = <<~OUTPUT
+        pub   rsa1024 2017-10-24 [SCEA]
+              18A0FC1C09C0D8AE34CE659257DC4AE323C7368C
+        uid           [ultimate] Joe Bloggs <pgp_test@iostreams.net>
+        sub   rsa1024 2017-10-24 [SEA]
+      OUTPUT
+
+      assert_equal 1, (keys = IOStreams::Pgp.parse_list_output(output)).size
+      key = keys.first
+      refute key[:private]
+      assert_equal 1024, key[:key_length]
+      assert_equal "rsa", key[:key_type]
+      assert_equal "18A0FC1C09C0D8AE34CE659257DC4AE323C7368C", key[:key_id]
+      assert_equal Date.new(2017, 10, 24), key[:date]
+      assert_equal "Joe Bloggs", key[:name]
+      assert_equal "pgp_test@iostreams.net", key[:email]
+      assert_equal "ultimate", key[:trust]
+    end
+
+    it "parses GnuPG 2.0.30 output (key id in the pub line, name on the uid line)" do
+      output = <<~OUTPUT
+        pub   4096R/3A5456F5 2017-06-07
+        uid       [ unknown] Joe Bloggs <j@bloggs.net>
+        sub   4096R/2C9B240B 2017-06-07
+      OUTPUT
+
+      assert_equal 1, (keys = IOStreams::Pgp.parse_list_output(output)).size
+      key = keys.first
+      refute key[:private]
+      assert_equal 4096, key[:key_length]
+      assert_equal "R", key[:key_type]
+      assert_equal "3A5456F5", key[:key_id]
+      assert_equal Date.new(2017, 6, 7), key[:date]
+      assert_equal "Joe Bloggs", key[:name]
+      assert_equal "j@bloggs.net", key[:email]
+      assert_equal "unknown", key[:trust]
+    end
+
+    it "parses GnuPG 2.0.x output with the name and email on the pub line" do
+      output = <<~OUTPUT
+        pub  2048R/C7F9D9CB 2016-10-26 Receiver <receiver@example.org>
+      OUTPUT
+
+      assert_equal 1, (keys = IOStreams::Pgp.parse_list_output(output)).size
+      key = keys.first
+      refute key[:private]
+      assert_equal 2048, key[:key_length]
+      assert_equal "R", key[:key_type]
+      assert_equal "C7F9D9CB", key[:key_id]
+      assert_equal Date.new(2016, 10, 26), key[:date]
+      assert_equal "Receiver", key[:name]
+      assert_equal "receiver@example.org", key[:email]
+      refute key.key?(:trust)
+    end
+
+    it "parses GnuPG 1.4 output (private/secret key, no trust)" do
+      output = <<~OUTPUT
+        sec   2048R/27D2E7FA 2016-10-05
+        uid                  Receiver <receiver@example.org>
+        ssb   2048R/893749EA 2016-10-05
+      OUTPUT
+
+      assert_equal 1, (keys = IOStreams::Pgp.parse_list_output(output)).size
+      key = keys.first
+      assert key[:private]
+      assert_equal 2048, key[:key_length]
+      assert_equal "R", key[:key_type]
+      assert_equal "27D2E7FA", key[:key_id]
+      assert_equal Date.new(2016, 10, 5), key[:date]
+      assert_equal "Receiver", key[:name]
+      assert_equal "receiver@example.org", key[:email]
+      refute key.key?(:trust)
+    end
+
+    it "parses a uid that has a name but no email" do
+      output = <<~OUTPUT
+        pub   rsa3072 2023-05-15 [SC]
+              ABCDEF0123456789ABCDEF0123456789ABCDEF01
+        uid           [ultimate] Joe Bloggs
+      OUTPUT
+
+      assert_equal 1, (keys = IOStreams::Pgp.parse_list_output(output)).size
+      key = keys.first
+      assert_equal "Joe Bloggs", key[:name]
+      assert_equal "ABCDEF0123456789ABCDEF0123456789ABCDEF01", key[:key_id]
+      assert_equal "ultimate", key[:trust]
+      refute key.key?(:email)
     end
   end
 end

--- a/test/pgp_writer_test.rb
+++ b/test/pgp_writer_test.rb
@@ -126,5 +126,43 @@ class PgpWriterTest < Minitest::Test
         assert_equal decrypted, result
       end
     end
+
+    describe "import_and_trust_key" do
+      let :public_key do
+        IOStreams::Pgp.export(email: "receiver@example.org")
+      end
+
+      it "imports and trusts the supplied key at the default ultimate level" do
+        captured = {}
+        stub = lambda do |**kwargs|
+          captured = kwargs
+          "receiver@example.org"
+        end
+        IOStreams::Pgp.stub(:import_and_trust, stub) do
+          IOStreams::Pgp::Writer.file(file_name, import_and_trust_key: public_key) { |io| io.write(decrypted) }
+        end
+        assert_equal 5, captured[:trust_level]
+
+        result = IOStreams::Pgp::Reader.file(file_name, passphrase: "receiver_passphrase", &:read)
+        assert_equal decrypted, result
+      end
+
+      it "passes the supplied import_and_trust_level through" do
+        captured = {}
+        stub = lambda do |**kwargs|
+          captured = kwargs
+          "receiver@example.org"
+        end
+        IOStreams::Pgp.stub(:import_and_trust, stub) do
+          IOStreams::Pgp::Writer.file(file_name, import_and_trust_key: public_key, import_and_trust_level: 4) do |io|
+            io.write(decrypted)
+          end
+        end
+        assert_equal 4, captured[:trust_level]
+
+        result = IOStreams::Pgp::Reader.file(file_name, passphrase: "receiver_passphrase", &:read)
+        assert_equal decrypted, result
+      end
+    end
   end
 end


### PR DESCRIPTION
## Overview
Five commits hardening three areas: PGP/GPG shell handling, the HTTP path against SSRF, and a smaller SFTP fix. Plus documentation and substantial new test coverage (`test/pgp_test.rb` +234, `test/paths/http_test.rb` +268).

## 1. PGP shell-injection elimination (`a01d649`)
The biggest change. Previously every `gpg` invocation was built as a single string and passed to `Open3`, so values like email addresses, key ids, passphrases, and filenames were interpreted by the shell.

- Added `Pgp.gpg_command` which builds an **argv array** (`Shellwords.split(executable) + args`), and converted every call site (`generate_key`, `list_keys`, `key_info`, `export`, `import`, `set_trust`, `fingerprint`, `pgp_version`, delete, reader, writer) to the multi-argument no-shell form of `Open3`.
- Rewrote `delete_public_or_private_keys_v1`, which previously shelled out to a `for` loop with interpolated `email`/`key_id` (a direct injection vector); it now lists fingerprints and deletes each one without a shell.
- Added `reject_newlines!` so `generate_key` parameters can't inject extra directives into the gpg batch parameter file.
- **Secret hygiene:** debug logging no longer emits passphrases. `generate_key` stops logging `params`, and `export`/`writer` stop logging the full command (which could contain `--passphrase`).

## 2. PGP trust level made explicit (`8f3c473`)
- `import_and_trust` and the writer's `file` method gained explicit `trust_level` / `import_and_trust_level` parameters (defaulting to the pre-existing `5`/Ultimate, so backward compatible).
- Added prominent **SECURITY WARNING** docs explaining that ultimately trusting an attacker-supplied key lets them impersonate other recipients, with guidance to use a lower level when a key can't be verified.

## 3. HTTP path hardened against SSRF (`2f6b1b6`)
- **`allow_hosts`** option: an allow-list validated against the original URL *and every redirect*, since redirect targets come from the remote server.
- **Redirect scheme validation:** redirects are re-checked to remain http(s); relative redirects are now resolved with `uri.merge`, and a missing `location` header raises.
- **Credential leak fix:** Basic auth credentials are only sent when the target is `same_origin?` as the original URL, so a redirect to another host can't capture them.
- **`maximum_file_size`** option: aborts the download if the body exceeds the limit (DoS protection against unbounded responses).
- `http_redirect_count: 0` now fully disables redirects.

## 4. SFTP argument quoting (`2f6b1b6`)
- The sftp `get` command now `.inspect`s the remote and local filenames so spaces/special characters in paths can't break the sftp batch command.

## 5. Documentation (`e6be965` + others)
- Added a code comment explaining why `zip_tricks` is used over `rubyzip` (streams to non-seekable S3/SFTP/HTTP outputs without a temp-file round-trip).
- New SSRF / trust-level guidance in `docs/path.md` and `docs/pgp.md`.

All changes preserve the public API (new options are additive with backward-compatible defaults).
