### PR TITLE
PGP enhancements: EC keys, sign-only files, and ignore_mdc_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - `csv` is now declared as a runtime dependency. It was a Ruby default gem through 3.3 but became a bundled gem in 3.4, so it must be declared to remain loadable under Bundler.
 - SimpleCov-based test coverage with substantially expanded tests across the suite.
+- `IOStreams::Pgp.generate_key` now supports Elliptic Curve keys and passphrase-less key generation. New `key_curve`, `key_usage`, `subkey_curve`, `subkey_usage`, and `creation_date` options are accepted, and passing `passphrase: nil` generates an unprotected key. These features require GnuPG 2.1 or later; on older versions the new options raise a clear error while existing RSA-with-passphrase generation is unchanged.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here.
 
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [2.0.0] - 2026-06-19
 
 ### Breaking
@@ -19,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - `csv` is now declared as a runtime dependency. It was a Ruby default gem through 3.3 but became a bundled gem in 3.4, so it must be declared to remain loadable under Bundler.
 - SimpleCov-based test coverage with substantially expanded tests across the suite.
 - `IOStreams::Pgp.generate_key` now supports Elliptic Curve keys and passphrase-less key generation. New `key_curve`, `key_usage`, `subkey_curve`, `subkey_usage`, and `creation_date` options are accepted, and passing `passphrase: nil` generates an unprotected key. These features require GnuPG 2.1 or later; on older versions the new options raise a clear error while existing RSA-with-passphrase generation is unchanged.
+- `IOStreams::Pgp::Reader` now accepts an `ignore_mdc_error:` option (default `false`). When enabled it passes `--ignore-mdc-error` to GnuPG so files lacking MDC (Modification Detection Code) integrity protection can be decrypted instead of failing with `gpg: decryption forced to fail!`. Some legacy/enterprise systems still produce such files. Only enable for files from a trusted source, since without MDC the decrypted contents are not protected against tampering.
 
 ### Security
 

--- a/docs/pgp.md
+++ b/docs/pgp.md
@@ -88,10 +88,11 @@ path.writer do |io|
 end
 ~~~
 
-Lets try to read the file:
+Lets try to read the file without supplying a passphrase:
 ~~~ruby
 IOStreams.path("sample/example.csv.pgp").read
-# ArgumentError (Missing both passphrase and IOStreams::Pgp::Reader.default_passphrase)
+# IOStreams::Pgp::Failure
+#  gpg: decryption failed: No secret key
 ~~~
 
 In order to decrypt the file it needs the passphrase for the receivers private key above:
@@ -137,6 +138,28 @@ path.read
 
 This time when we read the file the signature is automatically verified. However, this only works if the receiver
 has already imported the senders public key.
+
+##### Sign without encrypting
+
+Sometimes the contents do not need to be kept secret, but the recipient still needs to verify that the file came from
+the sender and was not tampered with. Set `encrypt: false` to sign the file without encrypting it. In this mode a
+`signer` is required, and `recipient` / `import_and_trust_key` are ignored:
+~~~ruby
+path = IOStreams.path("sample/example.csv.pgp")
+path.option(:pgp, encrypt: false, signer: "sender@example.org", signer_passphrase: "sender_passphrase")
+path.writer do |io|
+  io << "name,login\n"
+  io << "Jack Jones,jjones\n"
+  io << "Jill Smith,jsmith\n"
+end
+~~~
+
+Because a signed-only file is not encrypted, no passphrase is needed to read it. The signature is still verified
+automatically when the senders public key has been imported:
+~~~ruby
+IOStreams.path("sample/example.csv.pgp").read
+# => "name,login\nJack Jones,jjones\nJill Smith,jsmith\n"
+~~~
 
 ##### Auto-sign all files
 

--- a/lib/io_streams/pgp.rb
+++ b/lib/io_streams/pgp.rb
@@ -57,6 +57,20 @@ module IOStreams
     #   Highly Recommended.
     #   To generate a good passphrase:
     #     `SecureRandom.urlsafe_base64(128)`
+    #   Pass `nil` to generate an unprotected (passphrase-less) key.
+    #
+    # key_curve / subkey_curve [String]
+    #   Optional Elliptic Curve to use for the (sub)key, e.g. "ed25519".
+    #   When supplied the corresponding key/subkey length is ignored.
+    #   Requires GnuPG 2.1 or later.
+    #
+    # key_usage / subkey_usage [String]
+    #   Optional comma separated list of (sub)key capabilities, e.g. "sign".
+    #   Requires GnuPG 2.1 or later.
+    #
+    # creation_date [String]
+    #   Optional creation date for the key, e.g. "20240101T000000".
+    #   Requires GnuPG 2.1 or later.
     #
     # See `man gpg` for the remaining options
     def self.generate_key(name:,
@@ -67,25 +81,65 @@ module IOStreams
                           key_length: 4096,
                           subkey_type: "RSA",
                           subkey_length: key_length,
+                          key_curve: nil,
+                          key_usage: nil,
+                          subkey_curve: nil,
+                          subkey_usage: nil,
+                          creation_date: nil,
                           expire_date: nil)
       version_check
 
       # Reject newlines so that a value cannot inject additional directives into
       # the gpg batch key-generation parameter file.
       reject_newlines!(name: name, email: email, comment: comment, passphrase: passphrase,
-                       key_type: key_type, subkey_type: subkey_type, expire_date: expire_date)
+                       key_type: key_type, subkey_type: subkey_type, expire_date: expire_date,
+                       key_curve: key_curve, key_usage: key_usage,
+                       subkey_curve: subkey_curve, subkey_usage: subkey_usage,
+                       creation_date: creation_date)
+
+      # `%no-protection`, and the Elliptic Curve / usage / creation-date directives
+      # were all introduced in GnuPG 2.1. Keep older versions working by only
+      # emitting them when a 2.1+ binary is detected. `--batch --gen-key` accepts
+      # all of these on 2.1+, so there is no need for the newer `--full-gen-key`.
+      modern = pgp_version.to_f >= 2.1
+
+      unless modern
+        new_options = {
+          key_curve:     key_curve,
+          key_usage:     key_usage,
+          subkey_curve:  subkey_curve,
+          subkey_usage:  subkey_usage,
+          creation_date: creation_date
+        }.compact
+        unless new_options.empty?
+          raise(ArgumentError,
+                "IOStreams::Pgp.generate_key: #{new_options.keys.join(', ')} require GnuPG 2.1 or later " \
+                "(detected #{pgp_version})")
+        end
+      end
 
       params = +""
+      # `%no-protection` is a control statement and must precede the key parameters.
+      # GnuPG 2.1+ requires this explicit opt-out to create an unprotected key;
+      # older versions create one simply by omitting the Passphrase directive.
+      params << "%no-protection\n" if !passphrase && modern
       params << "Key-Type: #{key_type}\n" if key_type
-      params << "Key-Length: #{key_length}\n" if key_length
+      # Key-Length and Key-Curve are mutually exclusive: curves imply their own length.
+      params << "Key-Length: #{key_length}\n" if key_length && !key_curve
+      params << "Key-Curve: #{key_curve}\n" if key_curve
+      params << "Key-Usage: #{key_usage}\n" if key_usage
       params << "Subkey-Type: #{subkey_type}\n" if subkey_type
-      params << "Subkey-Length: #{subkey_length}\n" if subkey_length
+      params << "Subkey-Length: #{subkey_length}\n" if subkey_length && !subkey_curve
+      params << "Subkey-Curve: #{subkey_curve}\n" if subkey_curve
+      params << "Subkey-Usage: #{subkey_usage}\n" if subkey_usage
       params << "Name-Real: #{name}\n" if name
       params << "Name-Comment: #{comment}\n" if comment
       params << "Name-Email: #{email}\n" if email
       params << "Expire-Date: #{expire_date}\n" if expire_date
+      params << "Creation-Date: #{creation_date}\n" if creation_date
       params << "Passphrase: #{passphrase}\n" if passphrase
       params << "%commit"
+
       command = gpg_command("--batch", "--gen-key", "--no-tty")
 
       out, err, status = Open3.capture3(*command, binmode: true, stdin_data: params)

--- a/lib/io_streams/pgp/reader.rb
+++ b/lib/io_streams/pgp/reader.rb
@@ -20,18 +20,21 @@ module IOStreams
       #   Name of file to read from
       #
       # passphrase: [String]
-      #   Pass phrase for private key to decrypt the file with
+      #   Pass phrase for private key to decrypt the file with.
+      #   Not required when the file is signed but not encrypted.
       def self.file(file_name, passphrase: nil)
         # Cannot use `passphrase: self.default_passphrase` since it is considered private
         passphrase ||= default_passphrase
-        raise(ArgumentError, "Missing both passphrase and IOStreams::Pgp::Reader.default_passphrase") unless passphrase
 
         args = []
         # Use --pinentry-mode loopback for all GnuPG versions >= 2.1
         args += ["--pinentry-mode", "loopback"] if IOStreams::Pgp.pgp_version.to_f >= 2.1
         # Use --no-symkey-cache for GnuPG versions >= 2.4 to avoid caching session keys
         args << "--no-symkey-cache" if IOStreams::Pgp.pgp_version.to_f >= 2.4
-        args += ["--batch", "--no-tty", "--yes", "--decrypt", "--passphrase-fd", "0", file_name.to_s]
+        args += ["--batch", "--no-tty", "--yes", "--decrypt"]
+        # Only feed a passphrase when one is supplied; sign-only files need none.
+        args += ["--passphrase-fd", "0"] if passphrase
+        args << file_name.to_s
 
         command = IOStreams::Pgp.gpg_command(*args)
         IOStreams::Pgp.logger&.debug { "IOStreams::Pgp::Reader.open: #{command.shelljoin}" }

--- a/lib/io_streams/pgp/reader.rb
+++ b/lib/io_streams/pgp/reader.rb
@@ -22,7 +22,15 @@ module IOStreams
       # passphrase: [String]
       #   Pass phrase for private key to decrypt the file with.
       #   Not required when the file is signed but not encrypted.
-      def self.file(file_name, passphrase: nil)
+      #
+      # ignore_mdc_error: [true|false]
+      #   Decrypt files that lack MDC (Modification Detection Code) integrity protection.
+      #   Some legacy/enterprise systems (e.g. Workday) still produce such files, which
+      #   modern GnuPG refuses to decrypt with `gpg: decryption forced to fail!`.
+      #   Only enable this for files from a trusted source: without MDC the decrypted
+      #   contents are not protected against tampering.
+      #   Default: false
+      def self.file(file_name, passphrase: nil, ignore_mdc_error: false)
         # Cannot use `passphrase: self.default_passphrase` since it is considered private
         passphrase ||= default_passphrase
 
@@ -31,6 +39,7 @@ module IOStreams
         args += ["--pinentry-mode", "loopback"] if IOStreams::Pgp.pgp_version.to_f >= 2.1
         # Use --no-symkey-cache for GnuPG versions >= 2.4 to avoid caching session keys
         args << "--no-symkey-cache" if IOStreams::Pgp.pgp_version.to_f >= 2.4
+        args << "--ignore-mdc-error" if ignore_mdc_error
         args += ["--batch", "--no-tty", "--yes", "--decrypt"]
         # Only feed a passphrase when one is supplied; sign-only files need none.
         args += ["--passphrase-fd", "0"] if passphrase

--- a/lib/io_streams/pgp/writer.rb
+++ b/lib/io_streams/pgp/writer.rb
@@ -79,6 +79,14 @@ module IOStreams
       # compress_level: [Integer]
       #   Compression level
       #   Default: 6
+      #
+      # Note: There is intentionally no option here to disable MDC (Modification Detection
+      # Code) integrity protection on the files we produce. The reader exposes
+      # `ignore_mdc_error:` so we can *consume* legacy files that lack MDC (see Reader),
+      # but we never want to *generate* them: MDC is what protects the encrypted contents
+      # against tampering, and modern GnuPG mandates it for current ciphers anyway
+      # (`--disable-mdc` is a no-op unless an obsolete cipher is forced). Omitting MDC on
+      # output would only weaken files we create, with no upside for this library.
       def self.file(file_name,
                     encrypt: true,
                     recipient: nil,
@@ -104,18 +112,15 @@ module IOStreams
           end
 
         # Write to stdin, with the encrypted and/or signed contents being written to the file
-        args = ["--batch", "--no-tty", "--yes"]
-        args << "--encrypt" if encrypt
-        args += ["--sign", "--local-user", signer.to_s] if signer
-        if signer_passphrase
-          args += ["--pinentry-mode", "loopback"] if IOStreams::Pgp.pgp_version.to_f >= 2.1
-          args << "--no-symkey-cache" if IOStreams::Pgp.pgp_version.to_f >= 2.4
-          args += ["--passphrase", signer_passphrase.to_s]
-        end
-        args += ["-z", compress_level.to_s] if compress_level != 6
-        args += ["--compress-algo", compress.to_s] unless compress == :none
-        recipients.each { |address| args += ["--recipient", address.to_s] }
-        args += ["-o", file_name.to_s]
+        args = build_args(
+          file_name:         file_name,
+          encrypt:           encrypt,
+          signer:            signer,
+          signer_passphrase: signer_passphrase,
+          compress:          compress,
+          compress_level:    compress_level,
+          recipients:        recipients
+        )
         command = IOStreams::Pgp.gpg_command(*args)
 
         # Do not log the command, it may contain the signer passphrase.
@@ -140,6 +145,23 @@ module IOStreams
         end
         result
       end
+
+      def self.build_args(file_name:, encrypt:, signer:, signer_passphrase:, compress:, compress_level:, recipients:)
+        args = ["--batch", "--no-tty", "--yes"]
+        args << "--encrypt" if encrypt
+        args += ["--sign", "--local-user", signer.to_s] if signer
+        if signer_passphrase
+          args += ["--pinentry-mode", "loopback"] if IOStreams::Pgp.pgp_version.to_f >= 2.1
+          args << "--no-symkey-cache" if IOStreams::Pgp.pgp_version.to_f >= 2.4
+          args += ["--passphrase", signer_passphrase.to_s]
+        end
+        args += ["-z", compress_level.to_s] if compress_level != 6
+        args += ["--compress-algo", compress.to_s] unless compress == :none
+        recipients.each { |address| args += ["--recipient", address.to_s] }
+        args += ["-o", file_name.to_s]
+        args
+      end
+      private_class_method :build_args
 
       def self.collect_recipients(recipient, import_and_trust_key, import_and_trust_level)
         recipients = Array(recipient)

--- a/lib/io_streams/pgp/writer.rb
+++ b/lib/io_streams/pgp/writer.rb
@@ -26,13 +26,20 @@ module IOStreams
         @audit_recipient           = nil
       end
 
-      # Write to a PGP / GPG file, encrypting the contents as it is written.
+      # Write to a PGP / GPG file, encrypting and/or signing the contents as it is written.
       #
       # file_name: [String]
       #   Name of file to write to.
       #
+      # encrypt: [true|false]
+      #   Whether to encrypt the file for the supplied recipient(s).
+      #   When set to false the file is signed but not encrypted, in which case a
+      #   :signer must be supplied and :recipient / :import_and_trust_key are ignored.
+      #   Default: true
+      #
       # recipient: [String|Array<String>]
       #   One or more emails of users for which to encrypt the file.
+      #   Ignored when encrypt is false.
       #
       # import_and_trust_key: [String|Array<String>]
       #   One or more pgp keys to import and then use to encrypt the file.
@@ -73,6 +80,7 @@ module IOStreams
       #   Compression level
       #   Default: 6
       def self.file(file_name,
+                    encrypt: true,
                     recipient: nil,
                     import_and_trust_key: nil,
                     import_and_trust_level: 5,
@@ -80,19 +88,24 @@ module IOStreams
                     signer_passphrase: default_signer_passphrase,
                     compress: :zip,
                     compress_level: 6)
-        raise(ArgumentError, "Requires either :recipient or :import_and_trust_key") unless recipient || import_and_trust_key
+        if encrypt
+          raise(ArgumentError, "Requires either :recipient or :import_and_trust_key") unless recipient || import_and_trust_key
+        elsif !signer
+          raise(ArgumentError, "Requires a :signer when encrypt is false")
+        end
 
         compress_level = 0 if compress == :none
 
-        recipients = Array(recipient)
-        recipients << audit_recipient if audit_recipient
+        recipients =
+          if encrypt
+            collect_recipients(recipient, import_and_trust_key, import_and_trust_level)
+          else
+            []
+          end
 
-        Array(import_and_trust_key).each do |key|
-          recipients << IOStreams::Pgp.import_and_trust(key: key, trust_level: import_and_trust_level)
-        end
-
-        # Write to stdin, with encrypted contents being written to the file
-        args = ["--batch", "--no-tty", "--yes", "--encrypt"]
+        # Write to stdin, with the encrypted and/or signed contents being written to the file
+        args = ["--batch", "--no-tty", "--yes"]
+        args << "--encrypt" if encrypt
         args += ["--sign", "--local-user", signer.to_s] if signer
         if signer_passphrase
           args += ["--pinentry-mode", "loopback"] if IOStreams::Pgp.pgp_version.to_f >= 2.1
@@ -106,7 +119,8 @@ module IOStreams
         command = IOStreams::Pgp.gpg_command(*args)
 
         # Do not log the command, it may contain the signer passphrase.
-        IOStreams::Pgp.logger&.debug { "IOStreams::Pgp::Writer.open: encrypt -o #{file_name}" }
+        action = encrypt ? "encrypt" : "sign"
+        IOStreams::Pgp.logger&.debug { "IOStreams::Pgp::Writer.open: #{action} -o #{file_name}" }
 
         result = nil
         Open3.popen2e(*command) do |stdin, out, waith_thr|
@@ -126,6 +140,17 @@ module IOStreams
         end
         result
       end
+
+      def self.collect_recipients(recipient, import_and_trust_key, import_and_trust_level)
+        recipients = Array(recipient)
+        recipients << audit_recipient if audit_recipient
+
+        Array(import_and_trust_key).each do |key|
+          recipients << IOStreams::Pgp.import_and_trust(key: key, trust_level: import_and_trust_level)
+        end
+        recipients
+      end
+      private_class_method :collect_recipients
     end
   end
 end

--- a/test/pgp_reader_test.rb
+++ b/test/pgp_reader_test.rb
@@ -32,6 +32,19 @@ class PgpReaderTest < Minitest::Test
         end
       end
 
+      # We cannot reliably generate an MDC-less file across GnuPG versions (modern GnuPG
+      # mandates MDC), so this only verifies that ignore_mdc_error is accepted and remains
+      # harmless for a normal encrypted file. The flag's real effect is on legacy files.
+      it "decrypts with ignore_mdc_error enabled" do
+        IOStreams::Pgp::Writer.file(temp_file.path, recipient: "receiver@example.org") do |io|
+          io.write(decrypted)
+        end
+
+        result = IOStreams::Pgp::Reader.file(temp_file.path, passphrase: "receiver_passphrase", ignore_mdc_error: true, &:read)
+
+        assert_equal decrypted, result
+      end
+
       it "streams input" do
         io_string = StringIO.new("".b)
         IOStreams::Pgp::Writer.stream(io_string, recipient: "receiver@example.org", signer: "sender@example.org", signer_passphrase: "sender_passphrase") do |io|

--- a/test/pgp_test.rb
+++ b/test/pgp_test.rb
@@ -56,10 +56,66 @@ class PgpTest < Minitest::Test
       # Newlines would otherwise allow extra directives to be injected into the
       # gpg batch key-generation parameter file.
       it "rejects newlines in fields to prevent batch directive injection" do
-        %i[name email comment passphrase key_type subkey_type expire_date].each do |field|
+        %i[name email comment passphrase key_type subkey_type expire_date
+           key_curve key_usage subkey_curve subkey_usage creation_date].each do |field|
           args        = {name: user_name, email: email, passphrase: passphrase, key_length: 1024}
-          args[field] = "#{args[field]}\nKey-Type: RSA"
+          args[field] = "#{args[field] || 'sign'}\nKey-Type: RSA"
           assert_raises(ArgumentError) { IOStreams::Pgp.generate_key(**args) }
+        end
+      end
+
+      describe "on GnuPG 2.1 or later" do
+        before do
+          skip "Requires GnuPG 2.1 or later" unless IOStreams::Pgp.pgp_version.to_f >= 2.1
+        end
+
+        it "generates an unprotected key when passphrase is nil" do
+          key_id = IOStreams::Pgp.generate_key(name: user_name, email: email, key_length: 1024, passphrase: nil)
+
+          assert key_id
+        ensure
+          IOStreams::Pgp.delete_keys(email: email, public: true, private: true) if key_id
+        end
+
+        it "generates an Elliptic Curve key" do
+          key_id = IOStreams::Pgp.generate_key(
+            name:         user_name,
+            email:        email,
+            passphrase:   passphrase,
+            key_type:     "EDDSA",
+            key_curve:    "ed25519",
+            key_usage:    "sign",
+            subkey_type:  "ECDH",
+            subkey_curve: "cv25519"
+          )
+
+          assert key_id
+        ensure
+          IOStreams::Pgp.delete_keys(email: email, public: true, private: true) if key_id
+        end
+      end
+
+      describe "on GnuPG older than 2.1" do
+        before do
+          # Pretend an older binary is installed so the version guard is exercised
+          # without needing an actual legacy gpg on the test machine.
+          IOStreams::Pgp.instance_variable_set(:@pgp_version, "2.0.30")
+        end
+
+        after do
+          IOStreams::Pgp.instance_variable_set(:@pgp_version, nil)
+        end
+
+        it "rejects Elliptic Curve parameters that require GnuPG 2.1" do
+          error = assert_raises(ArgumentError) do
+            IOStreams::Pgp.generate_key(
+              name:       user_name,
+              email:      email,
+              passphrase: passphrase,
+              key_curve:  "ed25519"
+            )
+          end
+          assert_includes error.message, "2.1"
         end
       end
     end

--- a/test/pgp_writer_test.rb
+++ b/test/pgp_writer_test.rb
@@ -63,6 +63,23 @@ class PgpWriterTest < Minitest::Test
         assert_equal decrypted, result
       end
 
+      it "signs without encrypting" do
+        IOStreams::Pgp::Writer.file(file_name, encrypt: false, signer: "sender@example.org", signer_passphrase: "sender_passphrase") do |io|
+          io.write(decrypted)
+        end
+
+        # A signed-only file is not encrypted and so needs no passphrase to read.
+        result = IOStreams::Pgp::Reader.file(file_name, &:read)
+
+        assert_equal decrypted, result
+      end
+
+      it "raises when signing without encryption and no signer is supplied" do
+        assert_raises ArgumentError do
+          IOStreams::Pgp::Writer.file(file_name, encrypt: false) { |io| io.write(decrypted) }
+        end
+      end
+
       it "supports multiple recipients" do
         IOStreams::Pgp::Writer.file(file_name, recipient: %w[receiver@example.org receiver2@example.org], signer: "sender@example.org", signer_passphrase: "sender_passphrase") do |io|
           io.write(decrypted)


### PR DESCRIPTION
## Summary

Accumulated PGP enhancements on `feature/pgp_enhancements`. This branch is 3 commits ahead of `master`:

- **Elliptic Curve and passphrase-less key generation** — `IOStreams::Pgp.generate_key` gains `key_curve`, `key_usage`, `subkey_curve`, `subkey_usage`, and `creation_date`; `passphrase: nil` produces an unprotected key. Requires GnuPG 2.1+.
- **Sign PGP files without encryption** (#20) — the writer can sign-only when `encrypt: false` and a `signer` is supplied.
- **`ignore_mdc_error:` on the reader** (#23) — pass `--ignore-mdc-error` to GnuPG so files lacking MDC integrity protection (e.g. from Workday and other legacy/enterprise systems) decrypt instead of failing with `gpg: decryption forced to fail!`. Opt-in, defaults to `false`.

## Notes on #23

- Reader-only by design. No writer option to *disable* MDC: we never want to generate non-MDC files, and modern GnuPG mandates MDC anyway (`--disable-mdc` is a no-op for current ciphers). This rationale is documented inline in the writer.
- Refactored the writer's gpg argument assembly into a private `build_args` helper.
- The option flows through the public API for free: `IOStreams.path("file.pgp").option(:pgp, ignore_mdc_error: true).read`.

## Testing

- New reader test verifying `ignore_mdc_error` is accepted and decrypts correctly.
- `bundle exec rubocop` clean; PGP reader/writer test suites pass.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)