### PR TITLE
Rename default branch to main and add solargraph dev dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,3 +23,4 @@ gem "rubocop"
 gem "rubocop-minitest"
 gem "rubocop-rake"
 gem "simplecov", require: false
+gem "solargraph", require: false, platform: :ruby

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -77,7 +77,7 @@ IOStreams.register_extension(:xls, MyXls::Reader, MyXls::Writer)
 ~~~
 
 Similarly, to support a new storage location, supply a Path class for its URI scheme.
-See [IOStreams::Paths::S3](https://github.com/reidmorrison/iostreams/blob/master/lib/io_streams/paths/s3.rb)
+See [IOStreams::Paths::S3](https://github.com/reidmorrison/iostreams/blob/main/lib/io_streams/paths/s3.rb)
 for an example of what is required.
 
 ~~~ruby

--- a/docs/path.md
+++ b/docs/path.md
@@ -21,7 +21,7 @@ IOStreams supports accessing files in the following places:
 * HTTP(S) (Read only)
 
 Are you using another cloud provider and want to add support for your favorite?
-Checkout the supplied [IOStreams S3 path provider](https://github.com/reidmorrison/iostreams/blob/master/lib/io_streams/paths/s3.rb)
+Checkout the supplied [IOStreams S3 path provider](https://github.com/reidmorrison/iostreams/blob/main/lib/io_streams/paths/s3.rb)
 for an example of what is required. Pull requests welcome.
 
 ### File


### PR DESCRIPTION
## Summary

- Update the two hardcoded GitHub source links in the docs from `/blob/master/` to `/blob/main/`, following the default branch rename from `master` to `main`.
- Add the `solargraph` gem to the `Gemfile` for local development (e.g. the Ruby LSP / VS Code). It is `require: false` and scoped to `platform: :ruby`, so it has no effect on the gem at runtime and does not load under JRuby.

## Notes

The GitHub default branch has already been renamed `master` → `main`; this PR updates the in-repo references to match. CI triggers on bare `push`/`pull_request` with no branch filter, so it was unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)