### PR TITLE
Fix documentation inaccuracies and fill gaps

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -102,6 +102,22 @@ To explicity set the temp file location the following config option can be used:
 IOStreams.temp_dir = "/var/really_big_temp"
 ~~~
 
+### temp_file
+
+To work with a temporary file directly, `IOStreams.temp_file` yields a path inside `temp_dir`
+and deletes the file when the block completes:
+
+~~~ruby
+IOStreams.temp_file("export", ".csv") do |path|
+  path.write("Hello World")
+  # ... use the temp file ...
+end
+# The temp file has been deleted.
+~~~
+
+The first argument is a base file name to include in the generated temp file name, and the
+optional second argument is the file extension.
+
 ## logger
 
 IOStreams can log debug information, such as the external commands it runs for PGP and SFTP.

--- a/docs/copy_files.md
+++ b/docs/copy_files.md
@@ -37,10 +37,9 @@ target.copy_from(source)
 When the file name does not have file extensions that would allow IOStreams to infer what streams to apply,
 the streams can be explicitly set using `stream`.
 
-In this example, the file `CUSTOMER_DATA` 
-
-Decrypt the contents of file that was encrypted with Symmetric Encryption 
-PGP encrypt the output file and write it to `xyz.csv.pgp` using the pgp key that was imported for `a@a.com`.
+In this example, the file `CUSTOMER_DATA` has no extensions, so `stream(:enc)` tells IOStreams
+that its contents were encrypted with Symmetric Encryption. The decrypted contents are then
+PGP encrypted and written to `xyz.csv.pgp` using the pgp key for `receiver@example.org`.
 
 ~~~ruby
 input = IOStreams.path("CUSTOMER_DATA").stream(:enc)

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -15,7 +15,7 @@ Supported extensions:
 | `.bz2`           | BZip2                | Yes  | Yes   | `bzip2-ffi`                        |
 | `.enc`           | Symmetric Encryption | Yes  | Yes   | `symmetric-encryption`             |
 | `.gz`, `.gzip`   | GZip                 | Yes  | Yes   | None (Ruby standard library)       |
-| `.zip`           | Zip                  | Yes  | Yes   | `rubyzip` (read), `zip_kit` (write). On JRuby the built-in Java zip support is used. |
+| `.zip`           | Zip                  | Yes  | Yes   | `rubyzip` (read), `zip_kit` (write). On JRuby the built-in Java zip support is used for reading. |
 | `.pgp`, `.gpg`   | PGP                  | Yes  | Yes   | GnuPG command line program (`gpg`) |
 | `.xlsx`, `.xlsm` | Excel Spreadsheet    | Yes  | No    | `creek`                            |
 
@@ -62,8 +62,12 @@ Options:
   Default: nil (raise `Encoding::UndefinedConversionError` on invalid characters)
 
 * `cleaner: [nil|Symbol|Proc]`
-  Cleanse the data. `:printable` removes all non-printable characters except `\r` and `\n`.
-  A Proc can be supplied to perform custom cleansing.
+  Cleanse the data. Built-in rules:
+  * `:printable` removes all non-printable characters except `\r` and `\n`.
+  * `:replace_non_printable` replaces all non-printable characters except `\r` and `\n`
+    with the `replace` value, or an empty string when `replace` is nil.
+  A Proc can also be supplied to perform custom cleansing; it is called with the data
+  and the `replace` value after every read or write.
   Default: nil
 
 ## Registering a custom extension

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -97,8 +97,18 @@ Layout column definitions:
   and to space fill when rendering.
 * `:type` `:string` (default), `:integer`, or `:float`.
   Strings are left justified and space padded, numbers are right justified and zero padded.
-  Raises `IOStreams::Errors::ValueTooLong` when a value cannot be rendered in `size` characters.
+  Raises `IOStreams::Errors::ValueTooLong` when an `:integer` or `:float` value cannot be
+  rendered in `size` characters.
 * `:decimals` For `:float` columns, the number of decimal places to render.
+  Default: 2
+
+In addition to `layout`, the `:fixed` format takes one more option:
+
+* `truncate: [true|false]`
+  Whether to truncate string values that are longer than their column `:size` when writing.
+  When false, a string value that is too long raises `IOStreams::Errors::ValueTooLong`
+  instead of being truncated. Numeric values are never truncated.
+  Default: true
 
 ## Header options
 

--- a/docs/path.md
+++ b/docs/path.md
@@ -68,6 +68,24 @@ path = IOStreams.path("s3://bucket-name/path/example.csv")
 
   AWS Secret Access Key Id to use to access this bucket.
 
+* :region [String]
+
+  The AWS region to connect to.
+  Default: the region set in the environment variables or credential files.
+
+* :client [Aws::S3::Client | Hash]
+
+  Supply the AWS S3 Client instance to use for this path.
+  Or, when a Hash, build a new client using the hash parameters.
+
+~~~ruby
+client = Aws::S3::Client.new(endpoint: "https://s3.test.com")
+path   = IOStreams.path("s3://bucket/path/file_name.txt", client: client)
+
+# Or, pass the client parameters directly:
+path = IOStreams.path("s3://bucket/path/file_name.txt", client: {endpoint: "https://s3.test.com"})
+~~~
+
 Writer specific options:
 
 * :acl [String]
@@ -212,6 +230,11 @@ If the supplied file name string includes the `sftp` URI.
 path = IOStreams.path("sftp://hostname/path/example.csv")
 ~~~
 
+IOStreams reads and writes SFTP files by shelling out to the `sftp` command line program,
+so it must be installed and on the `PATH`. When a password is supplied the `sshpass`
+program is also required to pass the password to `sftp`. Additionally the `net-sftp` gem
+must be added to the `Gemfile` to use `each_child`.
+
 Read a file from a remote sftp server.
 ~~~ruby
 IOStreams.path("sftp://example.org/path/file.txt", 
@@ -222,7 +245,7 @@ IOStreams.path("sftp://example.org/path/file.txt",
   end
 ~~~
 
-Raises Net::SFTP::StatusException when the file could not be read.
+Raises `IOStreams::Errors::CommunicationsFailure` when the file could not be read or written.
 
 Write to a file on a remote sftp server.
 ~~~ruby
@@ -294,8 +317,20 @@ end
     The identity (private key) itself, supplied as a string.
     Under the covers the key is written to a temp file and then passed as `IdentityFile`.
 
+  * HostKey [String]
+
+    The expected SSH host key presented by the remote host, instead of storing it in the
+    `known_hosts` file. It must contain the entire line that would be stored in `known_hosts`,
+    including the hostname, ip address, key type and key value. The easiest way to generate
+    the required value is with `ssh-keyscan hostname`.
+    Under the covers the value is written to a temp file and then passed as `UserKnownHostsFile`.
+
   * Any other options supported by ssh_config.
     `man ssh_config` to see all available options.
+
+Notes:
+* Since the `sftp` program operates on local files, reading from or writing to an SFTP path
+  streams through a local temp file behind the scenes.
 
 ### HTTP (http://, https://)
 
@@ -329,6 +364,11 @@ Notes:
 * password: [String]
 
   Password to use use with basic authentication when the username is supplied.
+
+* parameters: [Hash]
+
+  Query parameters to append to the url as a query string.
+  For example, `parameters: {"type" => "csv"}` appends `?type=csv` to the url.
 
 * http_redirect_count: [Integer]
 

--- a/docs/pgp.md
+++ b/docs/pgp.md
@@ -24,11 +24,15 @@ Install [GnuPG](https://gnupg.org)
 
 Mac OSX via homebrew
 
-    brew install gpg2
+    brew install gnupg
     
-Redhat Linux
+Redhat / CentOS / Fedora Linux
 
-    rpm install gpg2
+    dnf install gnupg2
+
+Ubuntu / Debian Linux
+
+    apt-get install gnupg
 
 Confirm GnuPG is installed:
 
@@ -342,6 +346,17 @@ path.option(:pgp, recipient: "receiver@example.org", compress: :zlib)
 path.write("Hello World")
 ~~~
 
+The compression level can be adjusted with the `:compress_level` option, where `1` is the
+fastest and `9` compresses the most:
+
+~~~ruby
+path = IOStreams.path("sample/example.csv.pgp")
+path.option(:pgp, recipient: "receiver@example.org", compress: :zlib, compress_level: 9)
+path.write("Hello World")
+~~~
+
+Default: `6`
+
 Compression Performance
 * Running tests on an Early 2015 Macbook Pro Dual Core with Ruby v2.3.1
 ~~~
@@ -351,6 +366,25 @@ Compression Performance
     :zlib:  size: 241MB  write:  66s  read:  23s  ( 756KB Memory )
     :bzip2: size: 129MB  write: 430s  read: 130s  ( 5MB Memory )
 ~~~
+
+### Reading legacy files without MDC integrity protection
+
+Modern GnuPG refuses to decrypt files that lack MDC (Modification Detection Code) integrity
+protection, failing with `gpg: decryption forced to fail!`. Some legacy or enterprise systems
+still produce such files. To read them, supply the `ignore_mdc_error` option:
+
+~~~ruby
+path = IOStreams.path("sample/example.csv.pgp")
+path.option(:pgp, passphrase: "receiver_passphrase", ignore_mdc_error: true)
+path.read
+~~~
+
+> **Security warning**
+>
+> Only enable `ignore_mdc_error` for files from a trusted source: without MDC the decrypted
+> contents are not protected against tampering.
+
+Note: IOStreams never writes files without MDC, this option only applies when reading.
 
 ### PGP FAQ:
 
@@ -363,4 +397,4 @@ Select highest level: 5
 ### PGP Limitations
 
 * Designed for processing larger files since a process is spawned for each file processed.
-* For lots of small, in memory files, use the `opengpgme` library. For example to attach pgp files to emails.
+* For lots of small, in memory files, use the [gpgme](https://github.com/ueno/ruby-gpgme) library. For example to attach pgp files to emails.

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -26,6 +26,15 @@ IOStreams.path("example.csv").each do |line|
 end
 ~~~
 
+By default the line delimiter is auto-detected from the file, handling both Windows (`\r\n`)
+and Linux (`\n`) line endings. To break the file up by something other than its line endings,
+supply `delimiter`:
+~~~ruby
+IOStreams.path("example.txt").each(:line, delimiter: "|") do |line|
+  puts line
+end
+~~~
+
 When a line can contain embedded newlines, such as a CSV field wrapped in double quotes that
 spans multiple lines, supply `embedded_within` so those newlines are not treated as line endings:
 ~~~ruby
@@ -148,11 +157,14 @@ Notes:
 
 ## Notes
 
-* Due to the nature of Zip, both its Reader and Writer methods will create
-  a temp file when reading from or writing to a stream.
-  Recommended to use Gzip over Zip since it can be streamed without requiring temp files.
-* Zip becomes exponentially slower with very large files, especially files
-  that exceed 4GB when uncompressed. Highly recommend using GZip for large files.
+* Reading a Zip file requires the entire file to be available locally, so reading from a
+  stream (for example S3 or HTTP) downloads it into a temp file first.
+  Writing Zip is fully streamed, no temp file is required.
+* When writing, `entry_file_name` sets the name of the file entry within the zip file.
+  It defaults to the file name without the `.zip` extension, so writing to
+  `example.csv.zip` creates an entry named `example.csv`.
+* Gzip is still recommended over Zip for very large files, since Zip files can only
+  be read via a local file.
 
 ## Pipeline
 


### PR DESCRIPTION
## Summary

Reviewed all pages in `docs/` against the current code, corrected the statements that no longer match the implementation, and documented options that existed in the code but not in the docs. No code changes.

### Corrections

- **streams.md**: The Zip notes said both reader and writer create temp files. The writer now streams via `zip_kit` with no temp file; only reading requires a local file. Also documented that the zip entry name defaults to the file name without `.zip`.
- **path.md**: SFTP failures raise `IOStreams::Errors::CommunicationsFailure`, not `Net::SFTP::StatusException` (the implementation shells out to the `sftp` binary). Documented the `sftp`/`sshpass` executable requirement and that `net-sftp` is only needed for `each_child`.
- **formats.md**: Fixed-width string values are truncated by default rather than raising `ValueTooLong`; only `:integer`/`:float` values always raise.
- **pgp.md**: Replaced the nonexistent `rpm install gpg2` with `dnf install gnupg2`, added Debian/Ubuntu, updated the brew formula to `gnupg`, and fixed the library reference from `opengpgme` to `gpgme`.
- **copy_files.md**: Completed a dangling half-sentence and fixed an email mismatch with its code example.
- **extensions.md**: Clarified that JRuby's built-in Java zip support applies to reading only.

### Gaps filled

- **path.md**: S3 `region:` and `client:` arguments, SFTP `HostKey` ssh option, HTTP `parameters:` argument, and a note that SFTP streams through a local temp file.
- **formats.md**: The `:fixed` format `truncate:` option and the `:decimals` default of 2.
- **pgp.md**: The `compress_level:` option (default 6) and the reader's `ignore_mdc_error:` option with its security warning.
- **extensions.md**: The `:replace_non_printable` cleanser rule.
- **streams.md**: The `delimiter:` option for `:line` mode and line-ending auto-detection.
- **config.md**: New section documenting `IOStreams.temp_file`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)